### PR TITLE
Reorganise routes

### DIFF
--- a/cypress/integration/authentication.ts
+++ b/cypress/integration/authentication.ts
@@ -3,24 +3,24 @@ import { defaultUser } from 'cypress/support/commands';
 describe('authentication', () => {
   context('when logged out', () => {
     it('protected pages redirect to login', () => {
-      cy.visit('/requests/new?test=param');
+      cy.visit('/dashboard/requests/new?test=param');
       cy.url().should(
         'eq',
         `${
           Cypress.config().baseUrl
-        }/login?redirect=%2Frequests%2Fnew%3Ftest%3Dparam`
+        }/login?redirect=%2Fdashboard%2Frequests%2Fnew%3Ftest%3Dparam`
       );
     });
 
     it('handles client side routing', () => {
       cy.visit('/login');
       cy.window().then((win) => {
-        win.next.router.push('/requests/new?test=param');
+        win.next.router.push('/dashboard/requests/new?test=param');
         cy.url().should(
           'eq',
           `${
             Cypress.config().baseUrl
-          }/login?redirect=%2Frequests%2Fnew%3Ftest%3Dparam`
+          }/login?redirect=%2Fdashboard%2Frequests%2Fnew%3Ftest%3Dparam`
         );
       });
     });
@@ -32,7 +32,7 @@ describe('authentication', () => {
       user.groups = ['some-other-group'];
       cy.login(user);
 
-      cy.visit('/requests/new');
+      cy.visit('/dashboard/requests/new');
 
       cy.get('h1').should('contain.text', 'Access denied');
     });

--- a/cypress/integration/create-evidence-request.spec.ts
+++ b/cypress/integration/create-evidence-request.spec.ts
@@ -13,7 +13,7 @@ describe('Create evidence requests', () => {
   });
 
   it('User can fill out new request form', () => {
-    cy.visit(`http://localhost:3000`);
+    cy.visit(`http://localhost:3000/dashboard`);
 
     cy.get('nav').contains('Requests').click();
     cy.get('h2').should('contain', 'Pending requests');

--- a/cypress/integration/view-evidence-requests.spec.ts
+++ b/cypress/integration/view-evidence-requests.spec.ts
@@ -7,7 +7,7 @@ describe('View evidence requests', () => {
   });
 
   it('User can view pending evidence requests', () => {
-    cy.visit(`http://localhost:3000`);
+    cy.visit(`http://localhost:3000/dashboard`);
     cy.get('nav').contains('Requests').click();
 
     cy.get('h2').should('contain', 'Pending requests');

--- a/package-lock.json
+++ b/package-lock.json
@@ -712,7 +712,7 @@
     },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.taobao.org/@cypress/listr-verbose-renderer/download/@cypress/listr-verbose-renderer-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
       "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
       "dev": true,
       "requires": {
@@ -724,19 +724,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz?cache=0&sync_timestamp=1591687018980&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -749,7 +749,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -758,7 +758,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz?cache=0&sync_timestamp=1598611790551&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -3618,7 +3618,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
@@ -3664,7 +3664,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -3745,7 +3745,7 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npm.taobao.org/aws-sign2/download/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
@@ -3994,7 +3994,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -4314,7 +4314,7 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npm.taobao.org/buffer-crc32/download/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
@@ -4492,7 +4492,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
@@ -4547,7 +4547,7 @@
     },
     "check-more-types": {
       "version": "2.24.0",
-      "resolved": "https://registry.npm.taobao.org/check-more-types/download/check-more-types-2.24.0.tgz",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
       "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
       "dev": true
     },
@@ -4725,7 +4725,7 @@
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
@@ -4764,7 +4764,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.taobao.org/cli-truncate/download/cli-truncate-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "dev": true,
       "requires": {
@@ -5571,7 +5571,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npm.taobao.org/dashdash/download/dashdash-1.14.1.tgz?cache=0&sync_timestamp=1601073407658&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdashdash%2Fdownload%2Fdashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -5639,7 +5639,7 @@
     },
     "de-indent": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "resolved": "https://registry.npm.taobao.org/de-indent/download/de-indent-1.0.2.tgz",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
     },
     "debug": {
@@ -5963,7 +5963,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -6000,8 +6000,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npm.taobao.org/detect-libc/download/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -6541,7 +6540,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/ecc-jsbn/download/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -6569,7 +6568,7 @@
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/elegant-spinner/download/elegant-spinner-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
@@ -7282,7 +7281,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -7296,7 +7295,7 @@
     },
     "exit-hook": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/exit-hook/download/exit-hook-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
@@ -7560,7 +7559,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -7568,7 +7567,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -7652,7 +7651,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/fd-slicer/download/fd-slicer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
@@ -7672,7 +7671,7 @@
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/figures/download/figures-1.7.0.tgz?cache=0&sync_timestamp=1581865349068&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffigures%2Fdownload%2Ffigures-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -7868,7 +7867,7 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/forever-agent/download/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -8188,7 +8187,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/getpass/download/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -8395,7 +8394,7 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/har-schema/download/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
@@ -8420,7 +8419,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -8429,7 +8428,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         }
@@ -8644,7 +8643,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/http-signature/download/http-signature-1.2.0.tgz?cache=0&sync_timestamp=1600868446752&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-signature%2Fdownload%2Fhttp-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -8829,7 +8828,7 @@
     },
     "indent-string": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/indent-string/download/indent-string-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
@@ -9337,7 +9336,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
@@ -9364,7 +9363,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -9384,7 +9383,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -10884,7 +10883,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
@@ -11021,7 +11020,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npm.taobao.org/json-schema/download/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
@@ -11038,7 +11037,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -11094,7 +11093,7 @@
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.taobao.org/jsprim/download/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -11307,7 +11306,7 @@
     },
     "lazy-ass": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/lazy-ass/download/lazy-ass-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "dev": true
     },
@@ -11450,7 +11449,7 @@
       "dependencies": {
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npm.taobao.org/is-stream/download/is-stream-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         }
@@ -11458,7 +11457,7 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/listr-silent-renderer/download/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
@@ -11480,19 +11479,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz?cache=0&sync_timestamp=1591687018980&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11505,7 +11504,7 @@
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/log-symbols/download/log-symbols-1.0.2.tgz?cache=0&sync_timestamp=1587899104696&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flog-symbols%2Fdownload%2Flog-symbols-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
@@ -11514,7 +11513,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11523,7 +11522,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz?cache=0&sync_timestamp=1598611790551&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsupports-color%2Fdownload%2Fsupports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -11543,7 +11542,7 @@
       "dependencies": {
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -11552,7 +11551,7 @@
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/figures/download/figures-2.0.0.tgz?cache=0&sync_timestamp=1581865349068&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffigures%2Fdownload%2Ffigures-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -11567,7 +11566,7 @@
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/onetime/download/onetime-2.0.1.tgz?cache=0&sync_timestamp=1597003442669&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fonetime%2Fdownload%2Fonetime-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -11576,7 +11575,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/restore-cursor/download/restore-cursor-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -11917,7 +11916,7 @@
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/lodash.once/download/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
@@ -12016,7 +12015,7 @@
     },
     "log-update": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/log-update/download/log-update-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
@@ -12027,7 +12026,7 @@
       "dependencies": {
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -12042,7 +12041,7 @@
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/onetime/download/onetime-2.0.1.tgz?cache=0&sync_timestamp=1597003442669&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fonetime%2Fdownload%2Fonetime-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -12051,7 +12050,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/restore-cursor/download/restore-cursor-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -12505,8 +12504,7 @@
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npm.taobao.org/mkdirp-classic/download/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM=",
-      "optional": true
+      "integrity": "sha1-+hDJEVzG2IZb4iG6R+6b7XhgERM="
     },
     "module-definition": {
       "version": "3.3.1",
@@ -13090,7 +13088,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/onetime/download/onetime-1.1.0.tgz?cache=0&sync_timestamp=1597003442669&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fonetime%2Fdownload%2Fonetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -13170,7 +13168,7 @@
     },
     "ospath": {
       "version": "1.2.2",
-      "resolved": "https://registry.npm.taobao.org/ospath/download/ospath-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
       "dev": true
     },
@@ -13489,13 +13487,13 @@
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/pend/download/pend-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/performance-now/download/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
@@ -13847,7 +13845,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npm.taobao.org/pretty-hrtime/download/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "pretty-quick": {
@@ -14502,7 +14500,7 @@
     },
     "request-progress": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/request-progress/download/request-progress-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
       "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
       "dev": true,
       "requires": {
@@ -14672,7 +14670,7 @@
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/restore-cursor/download/restore-cursor-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
@@ -15452,8 +15450,7 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npm.taobao.org/simple-concat/download/simple-concat-1.0.1.tgz",
-      "integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8=",
-      "optional": true
+      "integrity": "sha1-9Gl2CCujXCJj8cirXt/ibEHJVS8="
     },
     "simple-get": {
       "version": "4.0.0",
@@ -15516,7 +15513,7 @@
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npm.taobao.org/slice-ansi/download/slice-ansi-0.0.4.tgz?cache=0&sync_timestamp=1581873102461&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fslice-ansi%2Fdownload%2Fslice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -15721,7 +15718,6 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -15736,8 +15732,7 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -15758,7 +15753,6 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           },
@@ -15767,8 +15761,7 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -16703,7 +16696,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npm.taobao.org/tar-fs/download/tar-fs-2.1.1.tgz",
       "integrity": "sha1-SJoVq4Xx8L76uzcLfeT561y+h4Q=",
-      "optional": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -16897,7 +16889,7 @@
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/throttleit/download/throttleit-1.0.0.tgz?cache=0&sync_timestamp=1584933713981&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fthrottleit%2Fdownload%2Fthrottleit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
@@ -17193,7 +17185,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz?cache=0&sync_timestamp=1581364203962&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftweetnacl%2Fdownload%2Ftweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
@@ -17512,7 +17504,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npm.taobao.org/verror/download/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -17657,7 +17649,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -17718,7 +17709,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npm.taobao.org/is-number/download/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -17733,7 +17723,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz?cache=0&sync_timestamp=1579193926808&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fkind-of%2Fdownload%2Fkind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -17767,8 +17756,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-          "optional": true
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -18057,7 +18045,7 @@
     },
     "wrap-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-3.0.1.tgz?cache=0&sync_timestamp=1589250991473&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwrap-ansi%2Fdownload%2Fwrap-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
       "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
       "dev": true,
       "requires": {
@@ -18067,13 +18055,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -18089,7 +18077,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -18259,7 +18247,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npm.taobao.org/yauzl/download/yauzl-2.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -38,10 +38,10 @@ const Layout: FunctionComponent = ({ children }) => {
           <nav className={styles['layout__sidebar']}>
             <ul className="lbh-list">
               <li>
-                <NavLink href="/">Residents</NavLink>
+                <NavLink href="/dashboard">Residents</NavLink>
               </li>
               <li>
-                <NavLink href="/requests">Requests</NavLink>
+                <NavLink href="/dashboard/requests">Requests</NavLink>
               </li>
             </ul>
           </nav>

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -2,13 +2,13 @@ import { useState, useEffect, useMemo } from 'react';
 import Head from 'next/head';
 import { Heading, HeadingLevels } from 'lbh-frontend-react';
 import { ReactNode } from 'react';
-import { EvidenceRequest } from '../domain/evidence-request';
-import { InternalApiGateway } from '../gateways/internal-api';
-import { EvidenceRequestTable } from '../components/EvidenceRequestTable';
-import ResidentSearchForm from '../components/ResidentSearchForm';
-import Tabs from '../components/Tabs';
-import TableSkeleton from '../components/TableSkeleton';
-import Layout from '../components/DashboardLayout';
+import { EvidenceRequest } from '../../domain/evidence-request';
+import { InternalApiGateway } from '../../gateways/internal-api';
+import { EvidenceRequestTable } from '../../components/EvidenceRequestTable';
+import ResidentSearchForm from '../../components/ResidentSearchForm';
+import Tabs from '../../components/Tabs';
+import TableSkeleton from '../../components/TableSkeleton';
+import Layout from '../../components/DashboardLayout';
 
 const BrowseResidents = (): ReactNode => {
   const [evidenceRequests, setEvidenceRequests] = useState<EvidenceRequest[]>();

--- a/src/pages/dashboard/requests/index.tsx
+++ b/src/pages/dashboard/requests/index.tsx
@@ -2,10 +2,10 @@ import Head from 'next/head';
 import { Heading, HeadingLevels } from 'lbh-frontend-react';
 import Link from 'next/link';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
-import { EvidenceRequest } from '../../domain/evidence-request';
-import { InternalApiGateway } from '../../gateways/internal-api';
-import { EvidenceRequestTable } from '../../components/EvidenceRequestTable';
-import TableSkeleton from '../../components/TableSkeleton';
+import { EvidenceRequest } from '../../../domain/evidence-request';
+import { InternalApiGateway } from '../../../gateways/internal-api';
+import { EvidenceRequestTable } from '../../../components/EvidenceRequestTable';
+import TableSkeleton from '../../../components/TableSkeleton';
 import Layout from 'src/components/DashboardLayout';
 
 const RequestsIndexPage = (): ReactNode => {
@@ -30,7 +30,7 @@ const RequestsIndexPage = (): ReactNode => {
       </Head>
       <Heading level={HeadingLevels.H2}>Pending requests</Heading>
       {table}
-      <Link href="/requests/new">
+      <Link href="/dashboard/requests/new">
         <a className="govuk-button lbh-button">New request</a>
       </Link>
     </Layout>

--- a/src/pages/dashboard/requests/new.tsx
+++ b/src/pages/dashboard/requests/new.tsx
@@ -1,12 +1,12 @@
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
 import { Heading, HeadingLevels, Paragraph } from 'lbh-frontend-react';
-import NewRequestForm from '../../components/NewRequestForm';
+import NewRequestForm from '../../../components/NewRequestForm';
 import {
   EvidenceRequestRequest,
   InternalApiGateway,
-} from '../../gateways/internal-api';
-import { DocumentType } from '../../domain/document-type';
+} from '../../../gateways/internal-api';
+import { DocumentType } from '../../../domain/document-type';
 import Layout from 'src/components/DashboardLayout';
 
 const RequestsNewPage = (): ReactNode => {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -7,7 +7,7 @@ import Layout from '../components/ResidentLayout';
 const Home = (): ReactNode => {
   const router = useRouter();
   const loginUrl = useMemo(() => {
-    const { redirect = '/' } = router.query as { redirect?: string };
+    const { redirect = '/dashboard' } = router.query as { redirect?: string };
     return createLoginUrl(redirect);
   }, [router]);
 


### PR DESCRIPTION
- move staff-facing routes under /dashboard, so that residents don't accidentally get a log in page any more if they visit the root url, and so we can properly build the staff-facing /resident routes.
- update cypress tests