### PR TITLE
Fix flaky Cypress spec

### DIFF
--- a/cypress/integration/upload-a-document.spec.ts
+++ b/cypress/integration/upload-a-document.spec.ts
@@ -18,6 +18,8 @@ describe('Can upload a document', () => {
   });
 
   it('lets you choose a file', () => {
+    cy.visit(`http://localhost:3000/resident/foo`);
+    cy.get('a').contains('Continue').click();
     cy.get('h1').should('contain', 'Upload your documents');
     cy.get('input[type=file]').attachFile('example.png');
     cy.get('button').contains('Continue').click();


### PR DESCRIPTION
According to the docs, [Cypress specs should be able to run independently of each other](https://docs.cypress.io/guides/references/best-practices.html#Having-tests-rely-on-the-state-of-previous-tests). 

This is probably because tests do not run in the same order each time, which explains why the specs could only sometimes not find the input (it had not loaded yet).