### PR TITLE
Better tables

### DIFF
--- a/src/components/EvidenceRequestTable.tsx
+++ b/src/components/EvidenceRequestTable.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useMemo } from 'react';
 import { EvidenceRequest } from '../domain/evidence-request';
-import { Table } from 'lbh-frontend-react';
+import Link from 'next/link';
 
 export const EvidenceRequestTable: FunctionComponent<Props> = ({
   requests,
@@ -18,27 +18,55 @@ export const EvidenceRequestTable: FunctionComponent<Props> = ({
   );
 
   return (
-    <Table
-      columns={[
-        {
-          Header: 'Resident',
-          accessor: 'resident',
-          sortType: 'basic',
-        },
-        {
-          Header: 'Document',
-          accessor: 'document',
-          sortType: 'basic',
-        },
-        {
-          Header: 'Made',
-          accessor: 'made',
-          sortType: 'basic',
-        },
-      ]}
-      data={rows}
-      dueDateWarning={[]}
-    />
+    <table className="govuk-table  lbh-table">
+      <thead className="govuk-table__head">
+        <tr className="govuk-table__row">
+          <th scope="col" className="govuk-table__header">
+            Resident
+          </th>
+          <th
+            scope="col"
+            className="govuk-table__header govuk-table__header--numeric"
+          >
+            Document
+          </th>
+          <th
+            scope="col"
+            className="govuk-table__header govuk-table__header--numeric"
+          >
+            Made
+          </th>
+          <th
+            scope="col"
+            className="govuk-table__header govuk-table__header--numeric"
+          >
+            <span className="govuk-visually-hidden">Action</span>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody className="govuk-table__body">
+        {rows.map((row) => (
+          <tr className="govuk-table__row">
+            <td className="govuk-table__cell">{row.resident}</td>
+            <td className="govuk-table__cell govuk-table__cell--numeric">
+              {row.document}
+            </td>
+            <td className="govuk-table__cell govuk-table__cell--numeric">
+              {row.made}
+            </td>
+            <td className="govuk-table__cell govuk-table__cell--numeric lbh-body-s">
+              <Link href="#">
+                <a className="lbh-link">Remind</a>
+              </Link>
+              <Link href="#">
+                <a className="lbh-link lbh-link--red">Cancel</a>
+              </Link>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 };
 

--- a/src/components/ResidentTable.tsx
+++ b/src/components/ResidentTable.tsx
@@ -1,10 +1,7 @@
 import { FunctionComponent, useMemo } from 'react';
 import { EvidenceRequest } from '../domain/evidence-request';
-import { Table } from 'lbh-frontend-react';
 
-export const EvidenceRequestTable: FunctionComponent<Props> = ({
-  residents,
-}) => {
+export const ResidentTable: FunctionComponent<Props> = ({ residents }) => {
   const rows = useMemo(
     () =>
       residents.map((row) => {
@@ -18,27 +15,41 @@ export const EvidenceRequestTable: FunctionComponent<Props> = ({
   );
 
   return (
-    <Table
-      columns={[
-        {
-          Header: 'Resident',
-          accessor: 'resident',
-          sortType: 'basic',
-        },
-        {
-          Header: 'Document',
-          accessor: 'document',
-          sortType: 'basic',
-        },
-        {
-          Header: 'Uploaded',
-          accessor: 'uploaded',
-          sortType: 'basic',
-        },
-      ]}
-      data={rows}
-      dueDateWarning={[]}
-    />
+    <table className="govuk-table  lbh-table">
+      <thead className="govuk-table__head">
+        <tr className="govuk-table__row">
+          <th scope="col" className="govuk-table__header">
+            Resident
+          </th>
+          <th
+            scope="col"
+            className="govuk-table__header govuk-table__header--numeric"
+          >
+            Document
+          </th>
+          <th
+            scope="col"
+            className="govuk-table__header govuk-table__header--numeric"
+          >
+            Uploaded
+          </th>
+        </tr>
+      </thead>
+
+      <tbody className="govuk-table__body">
+        {rows.map((row) => (
+          <tr className="govuk-table__row">
+            <td className="govuk-table__cell">{row.resident}</td>
+            <td className="govuk-table__cell govuk-table__cell--numeric">
+              {row.document}
+            </td>
+            <td className="govuk-table__cell govuk-table__cell--numeric">
+              {row.uploaded}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 };
 

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -4,7 +4,7 @@ import { Heading, HeadingLevels } from 'lbh-frontend-react';
 import { ReactNode } from 'react';
 import { EvidenceRequest } from '../../domain/evidence-request';
 import { InternalApiGateway } from '../../gateways/internal-api';
-import { EvidenceRequestTable } from '../../components/EvidenceRequestTable';
+import { ResidentTable } from '../../components/ResidentTable';
 import ResidentSearchForm from '../../components/ResidentSearchForm';
 import Tabs from '../../components/Tabs';
 import TableSkeleton from '../../components/TableSkeleton';
@@ -22,7 +22,7 @@ const BrowseResidents = (): ReactNode => {
     if (!evidenceRequests)
       return <TableSkeleton columns={['Resident', 'Document', 'Made']} />;
 
-    return <EvidenceRequestTable requests={evidenceRequests} />;
+    return <ResidentTable residents={evidenceRequests} />;
   }, [evidenceRequests]);
 
   const handleSearch = () => {

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -48,3 +48,17 @@ body {
 .lbh-button--start {
   margin-bottom: 35px !important;
 }
+
+.lbh-link--red {
+  margin-left: 10px;
+  color: #be3a34 !important;
+  &:link {
+    color: #be3a34 !important;
+  }
+  &:visited {
+    color: #be3a34 !important;
+  }
+  &:focus {
+    color: inherit !important;
+  }
+}


### PR DESCRIPTION
- refactor resident search table to no longer use lbh-frontend-react's table component
- same for evidence request table
- make the resident search page actually use the right table