### PR TITLE
/api/v1 path in application, not in env var

### DIFF
--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -37,7 +37,7 @@ describe('Evidence api gateway', () => {
       expect(axios.request).toHaveBeenCalledWith({
         method,
         baseURL: baseUrl,
-        url: `/${path.join('/')}`,
+        url: `/api/v1/${path.join('/')}`,
         data: undefined,
         validateStatus,
         headers: {
@@ -73,7 +73,7 @@ describe('Evidence api gateway', () => {
       expect(axios.request).toHaveBeenCalledWith({
         method,
         baseURL: baseUrl,
-        url: `/${path.join('/')}`,
+        url: `/api/v1/${path.join('/')}`,
         data: body,
         headers: {
           Authorization: process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_POST,
@@ -147,7 +147,7 @@ describe('Evidence api gateway', () => {
       expect(axios.request).toHaveBeenCalledWith({
         method,
         baseURL: baseUrl,
-        url: `/${path.join('/')}`,
+        url: `/api/v1/${path.join('/')}`,
         data: undefined,
         validateStatus,
         headers: {

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -24,7 +24,7 @@ export class EvidenceApiGateway {
       const { status, data } = await axios.request({
         method,
         baseURL: process.env.EVIDENCE_API_BASE_URL,
-        url: `/${pathSegments.join('/')}`,
+        url: `/api/v1/${pathSegments.join('/')}`,
         data: body,
         headers: {
           Authorization: token,


### PR DESCRIPTION
To ensure our env vars are consistent
