### PR TITLE
DES-141: nest residents and evidence pages under /teams

### DIFF
--- a/cypress/integration/authentication.spec.ts
+++ b/cypress/integration/authentication.spec.ts
@@ -3,24 +3,24 @@ import { defaultUser } from 'cypress/support/commands';
 describe('authentication', () => {
   context('when logged out', () => {
     it('protected pages redirect to login', () => {
-      cy.visit('/dashboard/requests/new?test=param');
+      cy.visit('/teams/2/dashboard/requests/new?test=param');
       cy.url().should(
         'eq',
         `${
           Cypress.config().baseUrl
-        }/login?redirect=%2Fdashboard%2Frequests%2Fnew%3Ftest%3Dparam`
+        }/login?redirect=%2Fteams%2F2%2Fdashboard%2Frequests%2Fnew%3Ftest%3Dparam`
       );
     });
 
     it('handles client side routing', () => {
       cy.visit('/login');
       cy.window().then((win) => {
-        win.next.router.push('/dashboard/requests/new?test=param');
+        win.next.router.push('teams/2/dashboard/requests/new?test=param');
         cy.url().should(
           'eq',
           `${
             Cypress.config().baseUrl
-          }/login?redirect=%2Fdashboard%2Frequests%2Fnew%3Ftest%3Dparam`
+          }/login?redirect=%2Fteams%2F2%2Fdashboard%2Frequests%2Fnew%3Ftest%3Dparam%26teamId%3D2`
         );
       });
     });
@@ -31,7 +31,7 @@ describe('authentication', () => {
       const user = { ...defaultUser, groups: ['some-other-group'] };
       cy.login(user);
 
-      cy.visit('/dashboard/requests/new');
+      cy.visit('teams/2/dashboard/requests/new');
 
       cy.get('h1').should('contain.text', 'Access denied');
     });

--- a/cypress/integration/create-evidence-request.spec.ts
+++ b/cypress/integration/create-evidence-request.spec.ts
@@ -6,7 +6,7 @@ describe('Create evidence requests', () => {
       fixture: 'evidence_requests/id',
     }).as('postEvidenceRequests');
 
-    cy.visit(`http://localhost:3000/dashboard`);
+    cy.visit(`http://localhost:3000/teams/2/dashboard`);
     cy.injectAxe();
   });
 

--- a/cypress/integration/search-for-resident.spec.ts
+++ b/cypress/integration/search-for-resident.spec.ts
@@ -10,7 +10,7 @@ describe('Can search for a resident', () => {
       fixture: 'residents/search',
     });
 
-    cy.visit(`http://localhost:3000/dashboard`);
+    cy.visit(`http://localhost:3000/teams/2/dashboard`);
     cy.injectAxe();
   });
 

--- a/cypress/integration/team-pages-authentication.spec.ts
+++ b/cypress/integration/team-pages-authentication.spec.ts
@@ -1,0 +1,73 @@
+// team id 1 in teams.json is Google Group HackneyAll while defaultUser from commands.ts is not a member of it
+describe('all pages under teams check for google group membership', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  context(
+    'when attempting to view the evidence request dashboard for a team the user is not authenticated to see',
+    () => {
+      it('redirects to the teams landing page', () => {
+        cy.login();
+
+        cy.visit(`http://localhost:3000/teams/1/dashboard`);
+
+        cy.get('h1').should('contain.text', 'Choose a team');
+      });
+    }
+  );
+
+  context(
+    'when attempting to view the requests for a team the user is not authenticated to see',
+    () => {
+      it('redirects to the teams landing page', () => {
+        cy.login();
+
+        cy.visit(`http://localhost:3000/teams/1/dashboard/requests`);
+
+        cy.get('h1').should('contain.text', 'Choose a team');
+      });
+    }
+  );
+
+  context(
+    'when attempting to create a new request for a team the user is not authenticated to see',
+    () => {
+      it('redirects to the teams landing page', () => {
+        cy.login();
+
+        cy.visit(`http://localhost:3000/teams/1/dashboard/requests/new`);
+
+        cy.get('h1').should('contain.text', 'Choose a team');
+      });
+    }
+  );
+
+  context(
+    'when attempting to view the residents for a team the user is not authenticated to see',
+    () => {
+      it('redirects to the teams landing page', () => {
+        cy.login();
+
+        cy.visit(`http://localhost:3000/teams/1/dashboard/residents/123`);
+
+        cy.get('h1').should('contain.text', 'Choose a team');
+      });
+    }
+  );
+
+  context(
+    'when attempting to view documents for a team the user is not authenticated to see',
+    () => {
+      it('redirects to the teams landing page', () => {
+        cy.login();
+
+        cy.visit(
+          `http://localhost:3000/teams/1/dashboard/residents/123/document/123`
+        );
+
+        cy.get('h1').should('contain.text', 'Choose a team');
+      });
+    }
+  );
+});

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -11,7 +11,7 @@ describe('Can view and manage evidence', () => {
       });
     }).as('updateDocumentState');
 
-    cy.visit(`http://localhost:3000/dashboard`);
+    cy.visit(`http://localhost:3000/teams/2/dashboard`);
     cy.injectAxe();
 
     cy.get('a').contains('Review').click();

--- a/cypress/integration/view-evidence-requests.spec.ts
+++ b/cypress/integration/view-evidence-requests.spec.ts
@@ -6,7 +6,7 @@ describe('View evidence requests', () => {
       fixture: 'evidence_requests/index',
     });
 
-    cy.visit(`http://localhost:3000/dashboard`);
+    cy.visit(`http://localhost:3000/teams/2/dashboard`);
     cy.injectAxe();
   });
 
@@ -27,5 +27,9 @@ describe('View evidence requests', () => {
       .and('contain', 'ago');
   });
 });
+
+// 2 more
+// user is null
+// user cannot view evidence request for the given team ID
 
 export {};

--- a/cypress/integration/view-evidence-requests.spec.ts
+++ b/cypress/integration/view-evidence-requests.spec.ts
@@ -28,8 +28,4 @@ describe('View evidence requests', () => {
   });
 });
 
-// 2 more
-// user is null
-// user cannot view evidence request for the given team ID
-
 export {};

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -5,11 +5,19 @@ import styles from '../styles/DashboardLayout.module.scss';
 import skipLinkStyles from 'src/styles/SkipLink.module.scss';
 import { UserContext } from '../contexts/UserContext';
 import ResidentLayout from './ResidentLayout';
+import { TeamHelper } from '../services/team-helper';
+import Link from 'next/link';
 
-const Layout: FunctionComponent = ({ children }) => {
+const Layout: FunctionComponent<Props> = (props, { children }) => {
   const { user } = useContext(UserContext);
 
   if (!user) return <ResidentLayout>{children}</ResidentLayout>;
+
+  const teamHelper = new TeamHelper();
+  const currentTeam = teamHelper.getTeamFromId(
+    teamHelper.getTeamsJson(),
+    props.teamId
+  );
 
   return (
     <>
@@ -23,20 +31,27 @@ const Layout: FunctionComponent = ({ children }) => {
         serviceName="Upload"
         isServiceNameShort={true}
         isStackedOnMobile={true}
-        homepageUrl="/dashboard"
+        homepageUrl="/teams"
       >
         <p>{user.name}</p>
         <a href="#">Sign out</a>
       </Header>
 
       <Container>
-        <nav className={styles.switcher} aria-label="Switch service">
+        <nav className={styles.switcher} aria-label="Switch teams">
           <strong className={`lbh-heading-h5 ${styles['switcher__name']}`}>
-            Housing benefit
+            {currentTeam?.name}
           </strong>
-          <a href="#" className={`lbh-link ${styles['switcher__link']} `}>
-            Switch service
-          </a>
+          <Link
+            href={{
+              pathname: '/teams',
+              query: { teamId: props.teamId },
+            }}
+          >
+            <a className={`lbh-link ${styles['switcher__link']}`}>
+              Switch team
+            </a>
+          </Link>
         </nav>
       </Container>
 
@@ -45,21 +60,29 @@ const Layout: FunctionComponent = ({ children }) => {
           <nav className={styles['layout__sidebar']}>
             <ul className="lbh-list">
               <li>
-                <NavLink href="/dashboard">Residents</NavLink>
+                <NavLink href={`/teams/${props.teamId}/dashboard`}>
+                  Residents
+                </NavLink>
               </li>
               <li>
-                <NavLink href="/dashboard/requests">Requests</NavLink>
+                <NavLink href={`/teams/${props.teamId}/dashboard/requests`}>
+                  Requests
+                </NavLink>
               </li>
             </ul>
           </nav>
 
           <main className={styles['layout__pane']} id="main-content">
-            {children}
+            {props.children}
           </main>
         </div>
       </div>
     </>
   );
 };
+
+interface Props {
+  teamId: string;
+}
 
 export default Layout;

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -13,9 +13,8 @@ const Layout: FunctionComponent<Props> = (props, { children }) => {
 
   if (!user) return <ResidentLayout>{children}</ResidentLayout>;
 
-  const teamHelper = new TeamHelper();
-  const currentTeam = teamHelper.getTeamFromId(
-    teamHelper.getTeamsJson(),
+  const currentTeam = TeamHelper.getTeamFromId(
+    TeamHelper.getTeamsJson(),
     props.teamId
   );
 

--- a/src/components/EvidenceTile.test.tsx
+++ b/src/components/EvidenceTile.test.tsx
@@ -6,6 +6,7 @@ describe('EvidenceTile', () => {
   it('renders all the data expected', async () => {
     render(
       <EvidenceTile
+        teamId="123"
         residentId="123"
         id="123"
         title="Foo"
@@ -27,6 +28,7 @@ describe('EvidenceTile', () => {
   it('renders without actions if document has already been reviewed', async () => {
     render(
       <EvidenceTile
+        teamId="123"
         residentId="123"
         id="123"
         title="Foo"

--- a/src/components/EvidenceTile.tsx
+++ b/src/components/EvidenceTile.tsx
@@ -15,7 +15,7 @@ export const EvidenceTile: FunctionComponent<Props> = (props) => (
     <div>
       <Heading level={HeadingLevels.H3} className={styles.title}>
         <Link
-          href={`/dashboard/residents/${props.residentId}/document/${props.id}`}
+          href={`/teams/${props.teamId}/dashboard/residents/${props.residentId}/document/${props.id}`}
         >
           <a className="lbh-link">{props.title}</a>
         </Link>
@@ -29,13 +29,13 @@ export const EvidenceTile: FunctionComponent<Props> = (props) => (
     {props.toReview && (
       <div className={`lbh-body-s ${styles.actions}`}>
         <Link
-          href={`/dashboard/residents/${props.residentId}/document/${props.id}?action=accept`}
+          href={`/teams/${props.teamId}/dashboard/residents/${props.residentId}/document/${props.id}?action=accept`}
           scroll={false}
         >
           <a className="lbh-link">Accept</a>
         </Link>
         <Link
-          href={`/dashboard/residents/${props.residentId}/document/${props.id}?action=reject`}
+          href={`/teams/${props.teamId}/dashboard/residents/${props.residentId}/document/${props.id}?action=reject`}
           scroll={false}
         >
           <a className={`lbh-link ${styles.redLink}`}>Request new file</a>
@@ -57,6 +57,7 @@ interface ListProps {
 }
 
 interface Props {
+  teamId: string;
   residentId: string;
   id: string;
   format: string;

--- a/src/components/ResidentSummaryTable.tsx
+++ b/src/components/ResidentSummaryTable.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 export const ResidentSummaryTable: FunctionComponent<Props> = ({
   residents,
+  teamId,
 }) => {
   const rows = useMemo(
     () =>
@@ -48,7 +49,7 @@ export const ResidentSummaryTable: FunctionComponent<Props> = ({
               {row.phoneNumber}
             </td>
             <td className="govuk-table__cell">
-              <Link href={`/dashboard/residents/${row.id}`}>
+              <Link href={`/teams/${teamId}/dashboard/residents/${row.id}`}>
                 <a className="lbh-link">Review</a>
               </Link>
             </td>
@@ -61,6 +62,7 @@ export const ResidentSummaryTable: FunctionComponent<Props> = ({
 
 interface Props {
   residents: Array<Resident>;
+  teamId: string;
 }
 
 export default ResidentSummaryTable;

--- a/src/components/ResidentTable.tsx
+++ b/src/components/ResidentTable.tsx
@@ -2,7 +2,10 @@ import Link from 'next/link';
 import React, { FunctionComponent, useMemo } from 'react';
 import { EvidenceRequest } from '../domain/evidence-request';
 
-export const ResidentTable: FunctionComponent<Props> = ({ residents }) => {
+export const ResidentTable: FunctionComponent<Props> = ({
+  residents,
+  teamId,
+}) => {
   const rows = useMemo(
     () =>
       residents.map((row) => {
@@ -55,7 +58,7 @@ export const ResidentTable: FunctionComponent<Props> = ({ residents }) => {
               {row.uploaded}
             </td>
             <td className="govuk-table__cell govuk-table__cell--numeric">
-              <Link href={`/dashboard/residents/${row.id}`}>
+              <Link href={`/teams/${teamId}/dashboard/residents/${row.id}`}>
                 <a className="lbh-link">Review</a>
               </Link>
             </td>
@@ -68,4 +71,5 @@ export const ResidentTable: FunctionComponent<Props> = ({ residents }) => {
 
 type Props = {
   residents: EvidenceRequest[];
+  teamId: string;
 };

--- a/src/components/TeamsLayout.tsx
+++ b/src/components/TeamsLayout.tsx
@@ -16,9 +16,8 @@ const TeamsLayout: FunctionComponent = (props) => {
     teamId: string;
   };
   let currentTeam;
-  if (teamId != undefined) {
-    const teamHelper = new TeamHelper();
-    currentTeam = teamHelper.getTeamFromId(teamHelper.getTeamsJson(), teamId);
+  if (teamId !== undefined) {
+    currentTeam = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
   }
 
   return (

--- a/src/components/TeamsLayout.tsx
+++ b/src/components/TeamsLayout.tsx
@@ -4,11 +4,22 @@ import styles from '../styles/DashboardLayout.module.scss';
 import skipLinkStyles from 'src/styles/SkipLink.module.scss';
 import { UserContext } from '../contexts/UserContext';
 import Link from 'next/link';
-import { Team } from '../domain/team';
+import { useRouter } from 'next/router';
+import { TeamHelper } from '../services/team-helper';
 
-const TeamsLayout: FunctionComponent<Props> = (props) => {
+const TeamsLayout: FunctionComponent = (props) => {
   const { user } = useContext(UserContext);
   if (!user) return <></>;
+
+  const router = useRouter();
+  const { teamId } = router.query as {
+    teamId: string;
+  };
+  let currentTeam;
+  if (teamId != undefined) {
+    const teamHelper = new TeamHelper();
+    currentTeam = teamHelper.getTeamFromId(teamHelper.getTeamsJson(), teamId);
+  }
 
   return (
     <>
@@ -29,12 +40,12 @@ const TeamsLayout: FunctionComponent<Props> = (props) => {
         <a href="#">Sign out</a>
       </Header>
 
-      {props.currentTeam && (
+      {teamId && (
         <Container>
           <nav className={styles.switcher} aria-label="Switch service">
             <strong className={`lbh-heading-h5 ${styles['switcher__name']}`}>
-              <Link href={`/teams/${props.currentTeam.id}/dashboard`}>
-                <a className="lbh-link">Back to {props.currentTeam?.name}</a>
+              <Link href={`/teams/${teamId}/dashboard`}>
+                <a className="lbh-link">Back to {currentTeam?.name}</a>
               </Link>
             </strong>
           </nav>
@@ -51,9 +62,5 @@ const TeamsLayout: FunctionComponent<Props> = (props) => {
     </>
   );
 };
-
-interface Props {
-  currentTeam?: Team;
-}
 
 export default TeamsLayout;

--- a/src/pages/teams/[teamId]/dashboard/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/index.tsx
@@ -83,30 +83,18 @@ const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
 
 export const getServerSideProps = withAuth<BrowseResidentsProps>(
   async (ctx) => {
-    const requestAuthorizer = new RequestAuthorizer();
-    const user = requestAuthorizer.authoriseUser(ctx.req?.headers.cookie);
-
-    if (user == undefined) {
-      return {
-        redirect: {
-          destination: '/login',
-          permanent: false,
-        },
-      };
-    }
-
-    const teamHelper = new TeamHelper();
     const { teamId } = ctx.query as {
       teamId: string;
     };
-    const userAuthorizedToViewTeam = teamHelper.userAuthorizedToViewTeam(
-      teamHelper.getTeamsJson(),
+
+    const user = new RequestAuthorizer().authoriseUser(ctx.req?.headers.cookie);
+    const userAuthorizedToViewTeam = TeamHelper.userAuthorizedToViewTeam(
+      TeamHelper.getTeamsJson(),
       user,
       teamId
     );
 
     if (!userAuthorizedToViewTeam) {
-      console.log('User:', user, 'is not authorized to view team ID:', teamId);
       return {
         redirect: {
           destination: '/teams',

--- a/src/pages/teams/[teamId]/dashboard/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/index.tsx
@@ -1,18 +1,19 @@
 import { Heading, HeadingLevels } from 'lbh-frontend-react';
 import { NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { EvidenceRequest } from 'src/domain/evidence-request';
 import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
-import Layout from '../../components/DashboardLayout';
-import ResidentSearchForm from '../../components/ResidentSearchForm';
-import { ResidentTable } from '../../components/ResidentTable';
+import Layout from '../../../../components/DashboardLayout';
+import ResidentSearchForm from '../../../../components/ResidentSearchForm';
+import { ResidentTable } from '../../../../components/ResidentTable';
 import { useCallback, useState } from 'react';
-import { InternalApiGateway } from '../../gateways/internal-api';
-import { Resident } from '../../domain/resident';
-import { ResidentSummaryTable } from '../../components/ResidentSummaryTable';
-import TableSkeleton from '../../components/TableSkeleton';
-import Tabs from '../../components/Tabs';
+import { InternalApiGateway } from '../../../../gateways/internal-api';
+import { Resident } from '../../../../domain/resident';
+import { ResidentSummaryTable } from '../../../../components/ResidentSummaryTable';
+import TableSkeleton from '../../../../components/TableSkeleton';
+import Tabs from '../../../../components/Tabs';
 
 type BrowseResidentsProps = {
   evidenceRequests: EvidenceRequest[];
@@ -21,6 +22,11 @@ type BrowseResidentsProps = {
 const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
   evidenceRequests,
 }) => {
+  const router = useRouter();
+  const { teamId } = router.query as {
+    teamId: string;
+  };
+
   // see here https://www.carlrippon.com/typed-usestate-with-typescript/ to explain useState<Resident[]>()
   const [results, setResults] = useState<Resident[]>();
   const [formSearchQuery, setFormSearchQuery] = useState('');
@@ -40,7 +46,7 @@ const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
   }, []);
 
   return (
-    <Layout>
+    <Layout teamId={teamId}>
       <Head>
         <title>Browse residents</title>
       </Head>

--- a/src/pages/teams/[teamId]/dashboard/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/index.tsx
@@ -60,7 +60,7 @@ const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
 
       {loading && <TableSkeleton columns={['Name', 'Email', 'Phone Number']} />}
 
-      {results && <ResidentSummaryTable residents={results} />}
+      {results && <ResidentSummaryTable residents={results} teamId={teamId} />}
 
       <h2 className="lbh-heading-h3">Pending Requests</h2>
 
@@ -69,11 +69,11 @@ const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
         children={[
           <div key="1">
             <Heading level={HeadingLevels.H3}>To review</Heading>
-            <ResidentTable residents={evidenceRequests} />
+            <ResidentTable residents={evidenceRequests} teamId={teamId} />
           </div>,
           <div key="2">
             <Heading level={HeadingLevels.H3}>All residents</Heading>
-            <ResidentTable residents={evidenceRequests} />
+            <ResidentTable residents={evidenceRequests} teamId={teamId} />
           </div>,
         ]}
       />

--- a/src/pages/teams/[teamId]/dashboard/requests/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/index.tsx
@@ -1,12 +1,13 @@
 import { NextPage } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import Layout from 'src/components/DashboardLayout';
 import { EvidenceRequestState } from 'src/domain/enums/EvidenceRequestState';
 import { EvidenceRequest } from 'src/domain/evidence-request';
 import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
-import { EvidenceRequestTable } from '../../../components/EvidenceRequestTable';
+import { EvidenceRequestTable } from '../../../../../components/EvidenceRequestTable';
 
 type RequestsIndexPageProps = {
   evidenceRequests: EvidenceRequest[];
@@ -15,14 +16,19 @@ type RequestsIndexPageProps = {
 const RequestsIndexPage: NextPage<WithUser<RequestsIndexPageProps>> = ({
   evidenceRequests,
 }) => {
+  const router = useRouter();
+  const { teamId } = router.query as {
+    teamId: string;
+  };
+
   return (
-    <Layout>
+    <Layout teamId={teamId}>
       <Head>
         <title>Pending requests</title>
       </Head>
       <h1 className="lbh-heading-h2">Pending requests</h1>
       <EvidenceRequestTable requests={evidenceRequests} />
-      <Link href="/dashboard/requests/new">
+      <Link href={`/teams/${teamId}/dashboard/requests/new`}>
         <a className="govuk-button lbh-button">New request</a>
       </Link>
     </Layout>

--- a/src/pages/teams/[teamId]/dashboard/requests/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/index.tsx
@@ -1,33 +1,31 @@
 import { NextPage } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import Layout from 'src/components/DashboardLayout';
 import { EvidenceRequestState } from 'src/domain/enums/EvidenceRequestState';
 import { EvidenceRequest } from 'src/domain/evidence-request';
 import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
 import { EvidenceRequestTable } from '../../../../../components/EvidenceRequestTable';
+import { RequestAuthorizer } from '../../../../../services/request-authorizer';
+import { TeamHelper } from '../../../../../services/team-helper';
 
 type RequestsIndexPageProps = {
   evidenceRequests: EvidenceRequest[];
+  teamId: string;
 };
 
 const RequestsIndexPage: NextPage<WithUser<RequestsIndexPageProps>> = ({
   evidenceRequests,
+  teamId,
 }) => {
-  const router = useRouter();
-  const { teamId } = router.query as {
-    teamId: string;
-  };
-
   return (
     <Layout teamId={teamId}>
       <Head>
         <title>Pending requests</title>
       </Head>
       <h1 className="lbh-heading-h2">Pending requests</h1>
-      <EvidenceRequestTable requests={evidenceRequests} />
+      <EvidenceRequestTable requests={evidenceRequests} teamId={teamId} />
       <Link href={`/teams/${teamId}/dashboard/requests/new`}>
         <a className="govuk-button lbh-button">New request</a>
       </Link>
@@ -35,14 +33,36 @@ const RequestsIndexPage: NextPage<WithUser<RequestsIndexPageProps>> = ({
   );
 };
 
-export const getServerSideProps = withAuth<RequestsIndexPageProps>(async () => {
-  const gateway = new EvidenceApiGateway();
-  const evidenceRequests = await gateway.getEvidenceRequests(
-    EvidenceRequestState.PENDING
-  );
-  return {
-    props: { evidenceRequests },
-  };
-});
+export const getServerSideProps = withAuth<RequestsIndexPageProps>(
+  async (ctx) => {
+    const { teamId } = ctx.query as {
+      teamId: string;
+    };
+
+    const user = new RequestAuthorizer().authoriseUser(ctx.req?.headers.cookie);
+    const userAuthorizedToViewTeam = TeamHelper.userAuthorizedToViewTeam(
+      TeamHelper.getTeamsJson(),
+      user,
+      teamId
+    );
+
+    if (!userAuthorizedToViewTeam) {
+      return {
+        redirect: {
+          destination: '/teams',
+          permanent: false,
+        },
+      };
+    }
+
+    const gateway = new EvidenceApiGateway();
+    const evidenceRequests = await gateway.getEvidenceRequests(
+      EvidenceRequestState.PENDING
+    );
+    return {
+      props: { evidenceRequests, teamId },
+    };
+  }
+);
 
 export default RequestsIndexPage;

--- a/src/pages/teams/[teamId]/dashboard/requests/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/index.tsx
@@ -25,7 +25,7 @@ const RequestsIndexPage: NextPage<WithUser<RequestsIndexPageProps>> = ({
         <title>Pending requests</title>
       </Head>
       <h1 className="lbh-heading-h2">Pending requests</h1>
-      <EvidenceRequestTable requests={evidenceRequests} teamId={teamId} />
+      <EvidenceRequestTable requests={evidenceRequests} />
       <Link href={`/teams/${teamId}/dashboard/requests/new`}>
         <a className="govuk-button lbh-button">New request</a>
       </Link>

--- a/src/pages/teams/[teamId]/dashboard/requests/new.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/new.tsx
@@ -1,16 +1,17 @@
 import { Paragraph } from 'lbh-frontend-react';
 import { NextPage } from 'next';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 import Layout from 'src/components/DashboardLayout';
 import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
-import NewRequestForm from '../../../components/NewRequestForm';
-import { DocumentType } from '../../../domain/document-type';
+import NewRequestForm from '../../../../../components/NewRequestForm';
+import { DocumentType } from '../../../../../domain/document-type';
 import {
   EvidenceRequestRequest,
   InternalApiGateway,
-} from '../../../gateways/internal-api';
+} from '../../../../../gateways/internal-api';
 
 type RequestsNewPageProps = {
   documentTypes: DocumentType[];
@@ -20,6 +21,11 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
   documentTypes,
   user,
 }) => {
+  const router = useRouter();
+  const { teamId } = router.query as {
+    teamId: string;
+  };
+
   const [complete, setComplete] = useState(false);
 
   const handleSubmit = useCallback(async (values: EvidenceRequestRequest) => {
@@ -35,7 +41,7 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
   }, []);
 
   return (
-    <Layout>
+    <Layout teamId={teamId}>
       <Head>
         <title>Make a new request</title>
       </Head>

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentId].tsx
@@ -33,6 +33,9 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   documentSubmission: _documentSubmission,
 }) => {
   const router = useRouter();
+  const { teamId } = router.query as {
+    teamId: string;
+  };
   const {
     residentId,
     documentId,
@@ -58,7 +61,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   if (!document) return null;
 
   return (
-    <Layout>
+    <Layout teamId={teamId}>
       <Head>
         <title>
           {documentSubmission.documentType.title} | Firstname Surname

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentId].tsx
@@ -51,7 +51,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
     });
     setDocumentSubmission(updated);
     router.push(
-      `/dashboard/residents/${residentId}/document/${documentSubmission.id}`,
+      `/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmission.id}`,
       undefined,
       { shallow: true }
     );
@@ -69,7 +69,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       </Head>
 
       <h1 className="lbh-heading-h2">
-        <Link href={`/dashboard/residents/${residentId}`}>
+        <Link href={`/teams/${teamId}/dashboard/residents/${residentId}`}>
           <a className="lbh-link">Firstname Surname</a>
         </Link>
         <img src="/divider.svg" alt="" className="lbu-divider" />
@@ -79,13 +79,13 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       {documentSubmission.state === DocumentState.PENDING && (
         <div className={styles.actions}>
           <Link
-            href={`/dashboard/residents/${residentId}/document/${documentSubmission.id}?action=accept`}
+            href={`/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmission.id}?action=accept`}
             scroll={false}
           >
             <Button>Accept</Button>
           </Link>
           <Link
-            href={`/dashboard/residents/${residentId}/document/${documentSubmission.id}?action=reject`}
+            href={`/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmission.id}?action=reject`}
             scroll={false}
           >
             <Button className="govuk-button--secondary lbh-button--secondary">
@@ -117,7 +117,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
         onAccept={handleAccept}
         onDismiss={() =>
           router.push(
-            `/dashboard/residents/${residentId}/document/${documentId}`
+            `/teams/${teamId}/dashboard/residents/${residentId}/document/${documentId}`
           )
         }
       />
@@ -129,7 +129,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
         }}
         onDismiss={() =>
           router.push(
-            `/dashboard/residents/${residentId}/document/${documentId}`
+            `/teams/${teamId}/dashboard/residents/${residentId}/document/${documentId}`
           )
         }
       />

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
@@ -25,6 +25,7 @@ const ResidentPage: NextPage<WithUser> = () => {
       <h2 className="lbh-heading-h3">To review</h2>
       <EvidenceList>
         <EvidenceTile
+          teamId={teamId}
           residentId={residentId}
           id="123"
           title="Foo"
@@ -35,6 +36,7 @@ const ResidentPage: NextPage<WithUser> = () => {
           toReview
         />
         <EvidenceTile
+          teamId={teamId}
           residentId={residentId}
           id="123"
           title="Foo"
@@ -45,6 +47,7 @@ const ResidentPage: NextPage<WithUser> = () => {
           toReview
         />
         <EvidenceTile
+          teamId={teamId}
           residentId={residentId}
           id="123"
           title="Foo"
@@ -100,15 +103,7 @@ const ResidentPage: NextPage<WithUser> = () => {
 
       <EvidenceList twoColumns>
         <EvidenceTile
-          residentId={residentId as string}
-          id="123"
-          title="Foo"
-          createdAt="1 day ago"
-          fileSizeInBytes={1300000}
-          format="PDF"
-          purpose="Example form"
-        />
-        <EvidenceTile
+          teamId={teamId}
           residentId={residentId}
           id="123"
           title="Foo"
@@ -118,6 +113,17 @@ const ResidentPage: NextPage<WithUser> = () => {
           purpose="Example form"
         />
         <EvidenceTile
+          teamId={teamId}
+          residentId={residentId}
+          id="123"
+          title="Foo"
+          createdAt="1 day ago"
+          fileSizeInBytes={1300000}
+          format="PDF"
+          purpose="Example form"
+        />
+        <EvidenceTile
+          teamId={teamId}
           residentId={residentId}
           id="123"
           title="Foo"

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
@@ -9,12 +9,13 @@ import styles from 'src/styles/Resident.module.scss';
 
 const ResidentPage: NextPage<WithUser> = () => {
   const router = useRouter();
-  const { residentId } = router.query as {
+  const { teamId, residentId } = router.query as {
+    teamId: string;
     residentId: string;
   };
 
   return (
-    <Layout>
+    <Layout teamId={teamId}>
       <Head>
         <title>Firstname Surname</title>
       </Head>

--- a/src/pages/teams/index.tsx
+++ b/src/pages/teams/index.tsx
@@ -1,4 +1,3 @@
-import TeamsJson from '../../../teams.json';
 import { Team } from '../../domain/team';
 import { withAuth, WithUser } from '../../helpers/authed-server-side-props';
 import { NextPage } from 'next';
@@ -11,8 +10,6 @@ import TeamsList from '../../components/TeamsList';
 type TeamsProps = {
   teams: Team[];
 };
-
-const teamsJson: Team[] = JSON.parse(JSON.stringify(TeamsJson));
 
 const Teams: NextPage<WithUser<TeamsProps>> = ({ teams }) => {
   return (
@@ -30,7 +27,7 @@ const Teams: NextPage<WithUser<TeamsProps>> = ({ teams }) => {
 
 export const getServerSideProps = withAuth<TeamsProps>(async (ctx) => {
   const requestAuthorizer = new RequestAuthorizer();
-  const serviceAreaHelper = new TeamHelper();
+  const teamHelper = new TeamHelper();
 
   const user = requestAuthorizer.authoriseUser(ctx.req?.headers.cookie);
   let userTeams: Team[];
@@ -38,7 +35,7 @@ export const getServerSideProps = withAuth<TeamsProps>(async (ctx) => {
   if (user == undefined) {
     userTeams = [];
   } else {
-    userTeams = serviceAreaHelper.filterTeamsForUser(teamsJson, user);
+    userTeams = teamHelper.filterTeamsForUser(teamHelper.getTeamsJson(), user);
   }
 
   return {

--- a/src/pages/teams/index.tsx
+++ b/src/pages/teams/index.tsx
@@ -26,16 +26,13 @@ const Teams: NextPage<WithUser<TeamsProps>> = ({ teams }) => {
 };
 
 export const getServerSideProps = withAuth<TeamsProps>(async (ctx) => {
-  const requestAuthorizer = new RequestAuthorizer();
-  const teamHelper = new TeamHelper();
-
-  const user = requestAuthorizer.authoriseUser(ctx.req?.headers.cookie);
+  const user = new RequestAuthorizer().authoriseUser(ctx.req?.headers.cookie);
   let userTeams: Team[];
 
   if (user == undefined) {
     userTeams = [];
   } else {
-    userTeams = teamHelper.filterTeamsForUser(teamHelper.getTeamsJson(), user);
+    userTeams = TeamHelper.filterTeamsForUser(TeamHelper.getTeamsJson(), user);
   }
 
   return {

--- a/src/services/team-helper-helper.test.ts
+++ b/src/services/team-helper-helper.test.ts
@@ -10,7 +10,6 @@ const jwtPayload = {
 
 describe('Team Helper', () => {
   let instance: TeamHelper;
-  let result: Team[];
 
   beforeEach(() => {
     instance = new TeamHelper();
@@ -32,7 +31,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    result = instance.filterTeamsForUser(teamJson, jwtPayload);
+    const result = instance.filterTeamsForUser(teamJson, jwtPayload);
     expect(result).toHaveLength(2);
   });
 
@@ -52,7 +51,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    result = instance.filterTeamsForUser(teamJson, jwtPayload);
+    const result = instance.filterTeamsForUser(teamJson, jwtPayload);
     expect(result).toHaveLength(1);
     expect(result[0].googleGroup).toBe('team');
   });
@@ -73,7 +72,35 @@ describe('Team Helper', () => {
       },
     ];
 
-    result = instance.filterTeamsForUser(teamJson, jwtPayload);
+    const result = instance.filterTeamsForUser(teamJson, jwtPayload);
     expect(result).toHaveLength(0);
+  });
+
+  it('when the team can be found from the ID', () => {
+    const teamJson: Team[] = [
+      {
+        name: 'Team 1',
+        googleGroup: 'team-one',
+        id: '1',
+        reasons: [],
+      },
+    ];
+
+    const result = instance.getTeamFromId(teamJson, '1');
+    expect(result?.name).toBe('Team 1');
+  });
+
+  it('when the team cannot be found from the ID', () => {
+    const teamJson: Team[] = [
+      {
+        name: 'Team 1',
+        googleGroup: 'team-one',
+        id: '123',
+        reasons: [],
+      },
+    ];
+
+    const result = instance.getTeamFromId(teamJson, '1');
+    expect(result).toBeUndefined();
   });
 });

--- a/src/services/team-helper.test.ts
+++ b/src/services/team-helper.test.ts
@@ -9,12 +9,6 @@ const jwtPayload = {
 } as User;
 
 describe('Team Helper', () => {
-  let instance: TeamHelper;
-
-  beforeEach(() => {
-    instance = new TeamHelper();
-  });
-
   it('when the user is a member of all team groups', () => {
     const teamJson: Team[] = [
       {
@@ -31,7 +25,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    const result = instance.filterTeamsForUser(teamJson, jwtPayload);
+    const result = TeamHelper.filterTeamsForUser(teamJson, jwtPayload);
     expect(result).toHaveLength(2);
   });
 
@@ -51,7 +45,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    const result = instance.filterTeamsForUser(teamJson, jwtPayload);
+    const result = TeamHelper.filterTeamsForUser(teamJson, jwtPayload);
     expect(result).toHaveLength(1);
     expect(result[0].googleGroup).toBe('team');
   });
@@ -72,7 +66,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    const result = instance.filterTeamsForUser(teamJson, jwtPayload);
+    const result = TeamHelper.filterTeamsForUser(teamJson, jwtPayload);
     expect(result).toHaveLength(0);
   });
 
@@ -86,7 +80,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    const result = instance.getTeamFromId(teamJson, '1');
+    const result = TeamHelper.getTeamFromId(teamJson, '1');
     expect(result?.name).toBe('Team 1');
   });
 
@@ -100,7 +94,7 @@ describe('Team Helper', () => {
       },
     ];
 
-    const result = instance.getTeamFromId(teamJson, '1');
+    const result = TeamHelper.getTeamFromId(teamJson, '1');
     expect(result).toBeUndefined();
   });
 
@@ -120,9 +114,9 @@ describe('Team Helper', () => {
       },
     ];
 
-    let result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
+    let result = TeamHelper.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
     expect(result).toBeTruthy();
-    result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '2');
+    result = TeamHelper.userAuthorizedToViewTeam(teamJson, jwtPayload, '2');
     expect(result).toBeTruthy();
   });
 
@@ -142,9 +136,9 @@ describe('Team Helper', () => {
       },
     ];
 
-    let result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
+    let result = TeamHelper.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
     expect(result).toBeTruthy();
-    result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '2');
+    result = TeamHelper.userAuthorizedToViewTeam(teamJson, jwtPayload, '2');
     expect(result).toBeFalsy();
   });
 
@@ -158,7 +152,11 @@ describe('Team Helper', () => {
       },
     ];
 
-    const result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
+    const result = TeamHelper.userAuthorizedToViewTeam(
+      teamJson,
+      jwtPayload,
+      '1'
+    );
     expect(result).toBeFalsy();
   });
 });

--- a/src/services/team-helper.test.ts
+++ b/src/services/team-helper.test.ts
@@ -103,4 +103,62 @@ describe('Team Helper', () => {
     const result = instance.getTeamFromId(teamJson, '1');
     expect(result).toBeUndefined();
   });
+
+  it('when the user should be able to view both teams', () => {
+    const teamJson: Team[] = [
+      {
+        name: 'Team 1',
+        googleGroup: 'team',
+        id: '1',
+        reasons: [],
+      },
+      {
+        name: 'Team 2',
+        googleGroup: 'another-team',
+        id: '2',
+        reasons: [],
+      },
+    ];
+
+    let result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
+    expect(result).toBeTruthy();
+    result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '2');
+    expect(result).toBeTruthy();
+  });
+
+  it('when the user should be able to view one team', () => {
+    const teamJson: Team[] = [
+      {
+        name: 'Team 1',
+        googleGroup: 'team',
+        id: '1',
+        reasons: [],
+      },
+      {
+        name: 'Team 2',
+        googleGroup: 'different-team',
+        id: '2',
+        reasons: [],
+      },
+    ];
+
+    let result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
+    expect(result).toBeTruthy();
+    result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '2');
+    expect(result).toBeFalsy();
+  });
+
+  it('when the user should not be able to view any teams', () => {
+    const teamJson: Team[] = [
+      {
+        name: 'Team 1',
+        googleGroup: 'different-team',
+        id: '1',
+        reasons: [],
+      },
+    ];
+
+    const result = instance.userAuthorizedToViewTeam(teamJson, jwtPayload, '1');
+    expect(result).toBeFalsy();
+  });
 });

--- a/src/services/team-helper.ts
+++ b/src/services/team-helper.ts
@@ -13,6 +13,18 @@ export class TeamHelper {
     return teamsJson.filter((team) => user.groups.includes(team.googleGroup));
   }
 
+  public userAuthorizedToViewTeam(
+    teamsJson: Team[],
+    user: User,
+    teamId: string
+  ): boolean {
+    const userTeams = this.filterTeamsForUser(teamsJson, user);
+    const filterUserTeamsByTeamId = userTeams.filter(
+      (team) => team.id == teamId
+    );
+    return filterUserTeamsByTeamId.length > 0;
+  }
+
   public getTeamFromId(teamsJson: Team[], teamId: string): Team | undefined {
     return teamsJson.find((team) => team.id == teamId);
   }

--- a/src/services/team-helper.ts
+++ b/src/services/team-helper.ts
@@ -1,8 +1,19 @@
 import { Team } from '../domain/team';
 import { User } from '../domain/user';
+import TeamsJson from '../../teams.json';
+
+const teamsJson: Team[] = JSON.parse(JSON.stringify(TeamsJson));
 
 export class TeamHelper {
+  public getTeamsJson(): Team[] {
+    return teamsJson;
+  }
+
   public filterTeamsForUser(teamsJson: Team[], user: User): Team[] {
     return teamsJson.filter((team) => user.groups.includes(team.googleGroup));
+  }
+
+  public getTeamFromId(teamsJson: Team[], teamId: string): Team | undefined {
+    return teamsJson.find((team) => team.id == teamId);
   }
 }

--- a/src/services/team-helper.ts
+++ b/src/services/team-helper.ts
@@ -5,15 +5,36 @@ import TeamsJson from '../../teams.json';
 const teamsJson: Team[] = JSON.parse(JSON.stringify(TeamsJson));
 
 export class TeamHelper {
-  public getTeamsJson(): Team[] {
+  public static getTeamsJson(): Team[] {
     return teamsJson;
   }
 
-  public filterTeamsForUser(teamsJson: Team[], user: User): Team[] {
+  public static filterTeamsForUser(teamsJson: Team[], user: User): Team[] {
     return teamsJson.filter((team) => user.groups.includes(team.googleGroup));
   }
 
-  public userAuthorizedToViewTeam(
+  public static userAuthorizedToViewTeam(
+    teamsJson: Team[],
+    user: User | undefined,
+    teamId: string
+  ): boolean {
+    if (user == undefined) {
+      return false;
+    }
+
+    const userAuthorizedToViewTeam = this.userMemberOfTeamGoogleGroup(
+      teamsJson,
+      user,
+      teamId
+    );
+
+    if (!userAuthorizedToViewTeam) {
+      console.log('User:', user, 'is not authorized to view team ID:', teamId);
+    }
+    return userAuthorizedToViewTeam;
+  }
+
+  private static userMemberOfTeamGoogleGroup(
     teamsJson: Team[],
     user: User,
     teamId: string
@@ -25,7 +46,10 @@ export class TeamHelper {
     return filterUserTeamsByTeamId.length > 0;
   }
 
-  public getTeamFromId(teamsJson: Team[], teamId: string): Team | undefined {
+  public static getTeamFromId(
+    teamsJson: Team[],
+    teamId: string
+  ): Team | undefined {
     return teamsJson.find((team) => team.id == teamId);
   }
 }


### PR DESCRIPTION
- Paths are now `/teams/[teamId]/dashboard`
  - `/requests`
  - `/residents`
- Validate the user has access to the team for the `teamId` in the path `/teams/:teamId/…`
  - Perform this during `getServerSideProps` as it's here we can route to a different page if the user should not be able to access the team page