### PR TITLE
DES-159: provide a drop down list of reasons in new evidence request form

### DIFF
--- a/cypress/fixtures/evidence_requests/id.json
+++ b/cypress/fixtures/evidence_requests/id.json
@@ -20,5 +20,6 @@
       "description": "A valid UK full or provisional UK driving license"
     }
   ],
-  "serviceRequestedBy": "development-team-staging"
+  "serviceRequestedBy": "development-team-staging",
+  "reason": "staging-reason"
 }

--- a/cypress/fixtures/evidence_requests/index.json
+++ b/cypress/fixtures/evidence_requests/index.json
@@ -16,7 +16,8 @@
         "description": "A valid passport open at the photo page"
       }
     ],
-    "serviceRequestedBy": "development-team-staging"
+    "serviceRequestedBy": "development-team-staging",
+    "reason": "staging-reason"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
@@ -35,7 +36,8 @@
         "description": "A valid UK full or provisional UK driving license"
       }
     ],
-    "serviceRequestedBy": "development-team-staging"
+    "serviceRequestedBy": "development-team-staging",
+    "reason": "staging-reason"
   },
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
@@ -54,6 +56,7 @@
         "description": "A valid passport open at the photo page"
       }
     ],
-    "serviceRequestedBy": "development-team-staging"
+    "serviceRequestedBy": "development-team-staging",
+    "reason": "staging-reason"
   }
 ]

--- a/src/boundary/response-mapper.test.ts
+++ b/src/boundary/response-mapper.test.ts
@@ -25,8 +25,8 @@ describe('ResponseMapper', () => {
     });
 
     it('maps basic attributes', () => {
-      const { id, serviceRequestedBy } = responseJson;
-      expect(result).toMatchObject({ id, serviceRequestedBy });
+      const { id, serviceRequestedBy, reason } = responseJson;
+      expect(result).toMatchObject({ id, serviceRequestedBy, reason });
       expect(result).toBeInstanceOf(EvidenceRequest);
     });
 

--- a/src/components/ConfirmRequestDialog.test.tsx
+++ b/src/components/ConfirmRequestDialog.test.tsx
@@ -35,6 +35,8 @@ describe('Confirm Request Dialog', () => {
         email: 'frodo@bagend.com',
         phoneNumber: '0123',
       },
+      serviceRequestedBy: 'Example Service',
+      reason: 'example-reason',
     };
 
     beforeEach(() => {

--- a/src/components/ConfirmRequestDialog.tsx
+++ b/src/components/ConfirmRequestDialog.tsx
@@ -9,13 +9,14 @@ const humanisedMethods: Record<string, string> = {
   EMAIL: 'email',
   SMS: 'SMS',
 };
-const formatSentence = (deliveryMethods: string[]) => {
-  if (!deliveryMethods.length) return "You're about to make a request to:";
+const formatSentence = (deliveryMethods: string[], reason: string) => {
+  if (!deliveryMethods.length)
+    return `You're about to make a ${reason} request to`;
 
   const methods = deliveryMethods
     .map((dm) => humanisedMethods[dm])
     .join(' and ');
-  return `You're about to send a request by ${methods} to:`;
+  return `You're about to send a ${reason} request by ${methods} to:`;
 };
 
 const ConfirmRequestDialog: FunctionComponent<Props> = ({
@@ -32,7 +33,9 @@ const ConfirmRequestDialog: FunctionComponent<Props> = ({
       onDismiss={onDismiss}
       title="Are you sure you want to send this request?"
     >
-      <p className="lbh-body">{formatSentence(request.deliveryMethods)}</p>
+      <p className="lbh-body">
+        {formatSentence(request.deliveryMethods, request.reason)}
+      </p>
       <ul className="lbh-list lbh-list--bullet">
         <li>
           <strong>{request.resident.name}</strong>

--- a/src/components/ConfirmRequestDialog.tsx
+++ b/src/components/ConfirmRequestDialog.tsx
@@ -9,14 +9,13 @@ const humanisedMethods: Record<string, string> = {
   EMAIL: 'email',
   SMS: 'SMS',
 };
-const formatSentence = (deliveryMethods: string[], reason: string) => {
-  if (!deliveryMethods.length)
-    return `You're about to make a ${reason} request to`;
+const formatSentence = (deliveryMethods: string[]) => {
+  if (!deliveryMethods.length) return "You're about to make a request to:";
 
   const methods = deliveryMethods
     .map((dm) => humanisedMethods[dm])
     .join(' and ');
-  return `You're about to send a ${reason} request by ${methods} to:`;
+  return `You're about to send a request by ${methods} to:`;
 };
 
 const ConfirmRequestDialog: FunctionComponent<Props> = ({
@@ -34,8 +33,9 @@ const ConfirmRequestDialog: FunctionComponent<Props> = ({
       title="Are you sure you want to send this request?"
     >
       <p className="lbh-body">
-        {formatSentence(request.deliveryMethods, request.reason)}
+        Request reason: <strong>{request.reason}</strong>
       </p>
+      <p className="lbh-body">{formatSentence(request.deliveryMethods)}</p>
       <ul className="lbh-list lbh-list--bullet">
         <li>
           <strong>{request.resident.name}</strong>

--- a/src/components/NewRequestForm.test.tsx
+++ b/src/components/NewRequestForm.test.tsx
@@ -14,6 +14,18 @@ const documentTypes = documentTypesFixture.map((dt) =>
   ResponseMapper.mapDocumentType(dt)
 );
 
+const team = {
+  name: 'Example Service',
+  googleGroup: 'example-service',
+  id: '1',
+  reasons: [
+    {
+      name: 'example-reason',
+      id: '123',
+    },
+  ],
+};
+
 const promise = Promise.resolve();
 const mockHandler = jest.fn(() => promise);
 
@@ -25,6 +37,8 @@ const values = {
     name: 'Example name',
     phoneNumber: '07777777777',
   },
+  serviceRequestedBy: 'Example Service',
+  reason: 'example-reason',
 };
 
 const fillInForm = () => {
@@ -43,7 +57,11 @@ const fillInForm = () => {
 describe('NewRequestFormForm', () => {
   it('renders an uploader panel and a continue button', async () => {
     render(
-      <NewRequestForm documentTypes={documentTypes} onSubmit={mockHandler} />
+      <NewRequestForm
+        documentTypes={documentTypes}
+        team={team}
+        onSubmit={mockHandler}
+      />
     );
     expect(screen.getByLabelText('Name')).toBeVisible();
     expect(screen.getByLabelText('Email')).toBeVisible();
@@ -61,7 +79,11 @@ describe('NewRequestFormForm', () => {
 
   it('validates all three contact details and an evidence type are present', async () => {
     render(
-      <NewRequestForm documentTypes={documentTypes} onSubmit={mockHandler} />
+      <NewRequestForm
+        documentTypes={documentTypes}
+        team={team}
+        onSubmit={mockHandler}
+      />
     );
     fireEvent.click(screen.getByText('Send request'));
 
@@ -81,7 +103,11 @@ describe('NewRequestFormForm', () => {
 
   it('calls the submit handler', async () => {
     render(
-      <NewRequestForm documentTypes={documentTypes} onSubmit={mockHandler} />
+      <NewRequestForm
+        documentTypes={documentTypes}
+        team={team}
+        onSubmit={mockHandler}
+      />
     );
 
     fillInForm();
@@ -100,7 +126,11 @@ describe('NewRequestFormForm', () => {
 
   it('prevents double-submits', async () => {
     render(
-      <NewRequestForm documentTypes={documentTypes} onSubmit={mockHandler} />
+      <NewRequestForm
+        documentTypes={documentTypes}
+        team={team}
+        onSubmit={mockHandler}
+      />
     );
 
     fillInForm();

--- a/src/components/NewRequestForm.tsx
+++ b/src/components/NewRequestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button, ErrorMessage } from 'lbh-frontend-react';
 import Field from './Field';
 import Checkbox from './Checkbox';
@@ -8,6 +8,8 @@ import * as Yup from 'yup';
 import { DocumentType } from '../domain/document-type';
 import { EvidenceRequestRequest } from 'src/gateways/internal-api';
 import ConfirmRequestDialog from './ConfirmRequestDialog';
+import SelectOption from './SelectOption';
+import { Team } from '../domain/team';
 
 const schema = Yup.object().shape({
   resident: Yup.object().shape({
@@ -19,6 +21,8 @@ const schema = Yup.object().shape({
       "Please enter the resident's phone number"
     ),
   }),
+  reason: Yup.string(),
+  serviceRequestedBy: Yup.string(),
   deliveryMethods: Yup.array(),
   documentTypes: Yup.array().min(1, 'Please choose a document type'),
 });
@@ -29,13 +33,24 @@ const initialValues = {
     email: '',
     phoneNumber: '',
   },
+  reason: '',
+  serviceRequestedBy: '',
   documentTypes: [],
   deliveryMethods: ['SMS', 'EMAIL'],
 };
 
-const NewRequestForm = ({ documentTypes, onSubmit }: Props): JSX.Element => {
+const NewRequestForm = ({
+  documentTypes,
+  onSubmit,
+  team,
+}: Props): JSX.Element => {
   const [submitError, setSubmitError] = useState(false);
   const [request, setRequest] = useState<EvidenceRequestRequest>();
+
+  useEffect(() => {
+    initialValues.serviceRequestedBy = team.googleGroup;
+    initialValues.reason = team.reasons[0].name;
+  });
 
   const submitHandler = useCallback(
     async (values: typeof initialValues) => {
@@ -84,6 +99,14 @@ const NewRequestForm = ({ documentTypes, onSubmit }: Props): JSX.Element => {
                 : null
             }
           />
+
+          <div className="govuk-form-group lbh-form-group">
+            <SelectOption
+              label="What is this request for?"
+              name="reason"
+              values={team.reasons.map((reason) => reason.name)}
+            />
+          </div>
 
           <div className="govuk-form-group lbh-form-group">
             <div className="govuk-checkboxes lbh-checkboxes">
@@ -146,6 +169,7 @@ const NewRequestForm = ({ documentTypes, onSubmit }: Props): JSX.Element => {
 interface Props {
   documentTypes: Array<DocumentType>;
   onSubmit: (values: EvidenceRequestRequest) => Promise<void>;
+  team: Team;
 }
 
 export default NewRequestForm;

--- a/src/components/NewRequestForm.tsx
+++ b/src/components/NewRequestForm.tsx
@@ -29,8 +29,8 @@ const schema = Yup.object().shape({
 
 const NewRequestForm = ({
   documentTypes,
-  onSubmit,
   team,
+  onSubmit,
 }: Props): JSX.Element => {
   const [submitError, setSubmitError] = useState(false);
   const [request, setRequest] = useState<EvidenceRequestRequest>();

--- a/src/components/NewRequestForm.tsx
+++ b/src/components/NewRequestForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Button, ErrorMessage } from 'lbh-frontend-react';
 import Field from './Field';
 import Checkbox from './Checkbox';
@@ -21,23 +21,11 @@ const schema = Yup.object().shape({
       "Please enter the resident's phone number"
     ),
   }),
-  reason: Yup.string(),
   serviceRequestedBy: Yup.string(),
+  reason: Yup.string(),
   deliveryMethods: Yup.array(),
   documentTypes: Yup.array().min(1, 'Please choose a document type'),
 });
-
-const initialValues = {
-  resident: {
-    name: '',
-    email: '',
-    phoneNumber: '',
-  },
-  reason: '',
-  serviceRequestedBy: '',
-  documentTypes: [],
-  deliveryMethods: ['SMS', 'EMAIL'],
-};
 
 const NewRequestForm = ({
   documentTypes,
@@ -47,10 +35,17 @@ const NewRequestForm = ({
   const [submitError, setSubmitError] = useState(false);
   const [request, setRequest] = useState<EvidenceRequestRequest>();
 
-  useEffect(() => {
-    initialValues.serviceRequestedBy = team.googleGroup;
-    initialValues.reason = team.reasons[0].name;
-  });
+  const initialValues = {
+    resident: {
+      name: '',
+      email: '',
+      phoneNumber: '',
+    },
+    serviceRequestedBy: team.name,
+    reason: team.reasons[0].name,
+    documentTypes: [],
+    deliveryMethods: ['SMS', 'EMAIL'],
+  };
 
   const submitHandler = useCallback(
     async (values: typeof initialValues) => {

--- a/src/components/NewRequestForm.tsx
+++ b/src/components/NewRequestForm.tsx
@@ -163,8 +163,8 @@ const NewRequestForm = ({
 
 interface Props {
   documentTypes: Array<DocumentType>;
-  onSubmit: (values: EvidenceRequestRequest) => Promise<void>;
   team: Team;
+  onSubmit: (values: EvidenceRequestRequest) => Promise<void>;
 }
 
 export default NewRequestForm;

--- a/src/components/SelectOption.tsx
+++ b/src/components/SelectOption.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Field as FormikField } from 'formik';
+import { Label } from 'lbh-frontend-react';
+
+const SelectOption = (props: Props): JSX.Element => (
+  <div className="govuk-select">
+    <Label labelFor={props.name}>{props.label}</Label>
+
+    <FormikField
+      name={props.name}
+      id={props.name}
+      value={props.values[0]}
+      as="select"
+      className="govuk-select  lbh-select__label"
+    >
+      {props.values.map((option) => (
+        <option
+          className="govuk-select  lbh-select__option"
+          value={option}
+          key={option}
+        >
+          {option}
+        </option>
+      ))}
+    </FormikField>
+  </div>
+);
+
+export interface Props {
+  label: string;
+  name: string;
+  values: string[];
+}
+
+export default SelectOption;

--- a/src/components/SelectOption.tsx
+++ b/src/components/SelectOption.tsx
@@ -9,7 +9,6 @@ const SelectOption = (props: Props): JSX.Element => (
     <FormikField
       name={props.name}
       id={props.name}
-      value={props.values[0]}
       as="select"
       className="govuk-select  lbh-select__label"
     >

--- a/src/domain/evidence-request.ts
+++ b/src/domain/evidence-request.ts
@@ -9,6 +9,7 @@ export interface IEvidenceRequest {
   deliveryMethods: DeliveryMethod[];
   documentTypes: DocumentType[];
   serviceRequestedBy: string;
+  reason: string;
 }
 
 export enum DeliveryMethod {
@@ -23,6 +24,7 @@ export class EvidenceRequest implements IEvidenceRequest {
   deliveryMethods: DeliveryMethod[];
   documentTypes: DocumentType[];
   serviceRequestedBy: string;
+  reason: string;
 
   constructor(params: IEvidenceRequest) {
     this.id = params.id;
@@ -31,5 +33,6 @@ export class EvidenceRequest implements IEvidenceRequest {
     this.deliveryMethods = params.deliveryMethods;
     this.documentTypes = params.documentTypes;
     this.serviceRequestedBy = params.serviceRequestedBy;
+    this.reason = params.reason;
   }
 }

--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -195,7 +195,10 @@ describe('Evidence api gateway', () => {
       });
 
       it('calls axios correctly', async () => {
-        await gateway.getEvidenceRequests(EvidenceRequestState.PENDING);
+        await gateway.getEvidenceRequests(
+          'Housing benefit',
+          EvidenceRequestState.PENDING
+        );
         expect(client.get).toHaveBeenLastCalledWith(
           '/api/v1/evidence_requests',
           {
@@ -212,7 +215,7 @@ describe('Evidence api gateway', () => {
       });
 
       it('maps the response', async () => {
-        await gateway.getEvidenceRequests();
+        await gateway.getEvidenceRequests('Housing benefit');
 
         for (let i = 0; i < expectedData.length; i++) {
           expect(
@@ -222,7 +225,7 @@ describe('Evidence api gateway', () => {
       });
 
       it('returns mapped EvidenceTypes', async () => {
-        const result = await gateway.getEvidenceRequests();
+        const result = await gateway.getEvidenceRequests('Housing benefit');
         expect(result).toEqual(mappedData);
       });
     });
@@ -230,7 +233,8 @@ describe('Evidence api gateway', () => {
     describe('when there is an error', () => {
       it('returns internal server error', async () => {
         client.get.mockRejectedValue(new Error('Network error'));
-        const functionCall = () => gateway.getEvidenceRequests();
+        const functionCall = () =>
+          gateway.getEvidenceRequests('Housing benefit');
         expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -48,6 +48,7 @@ export class EvidenceApiGateway {
   }
 
   async getEvidenceRequests(
+    teamName: string,
     state?: EvidenceRequestState | null
   ): Promise<EvidenceRequest[]> {
     try {
@@ -55,8 +56,7 @@ export class EvidenceApiGateway {
         '/api/v1/evidence_requests',
         {
           headers: { Authorization: tokens?.evidence_requests?.GET },
-          // TODO: pass this in from the users chosen service after DES-25
-          params: { serviceRequestedBy: 'Housing benefit', state: state },
+          params: { serviceRequestedBy: teamName, state: state },
         }
       );
 

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -23,7 +23,8 @@ export interface EvidenceRequestRequest {
   deliveryMethods: string[];
   documentTypes: string[];
   resident: Omit<IResident, 'id'>;
-  serviceRequestedBy?: string;
+  serviceRequestedBy: string;
+  reason: string;
   userRequestedBy?: string;
 }
 

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -19,6 +19,8 @@ export class InternalServerError extends Error {
   }
 }
 
+// It was recently that Service Area and Service were renamed to Team and Reason
+// We have decided to keep serviceRequestedBy as it is for now, then later rename it to teamRequestedBy
 export interface EvidenceRequestRequest {
   deliveryMethods: string[];
   documentTypes: string[];

--- a/src/pages/teams/[teamId]/dashboard/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/index.tsx
@@ -94,7 +94,8 @@ export const getServerSideProps = withAuth<BrowseResidentsProps>(
       teamId
     );
 
-    if (!userAuthorizedToViewTeam) {
+    const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
+    if (!userAuthorizedToViewTeam || team === undefined) {
       return {
         redirect: {
           destination: '/teams',
@@ -104,7 +105,7 @@ export const getServerSideProps = withAuth<BrowseResidentsProps>(
     }
 
     const gateway = new EvidenceApiGateway();
-    const evidenceRequests = await gateway.getEvidenceRequests();
+    const evidenceRequests = await gateway.getEvidenceRequests(team.name);
     return {
       props: { evidenceRequests, teamId },
     };

--- a/src/pages/teams/[teamId]/dashboard/requests/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/index.tsx
@@ -46,7 +46,8 @@ export const getServerSideProps = withAuth<RequestsIndexPageProps>(
       teamId
     );
 
-    if (!userAuthorizedToViewTeam) {
+    const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
+    if (!userAuthorizedToViewTeam || team === undefined) {
       return {
         redirect: {
           destination: '/teams',
@@ -57,6 +58,7 @@ export const getServerSideProps = withAuth<RequestsIndexPageProps>(
 
     const gateway = new EvidenceApiGateway();
     const evidenceRequests = await gateway.getEvidenceRequests(
+      team.name,
       EvidenceRequestState.PENDING
     );
     return {

--- a/src/pages/teams/[teamId]/dashboard/requests/new.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/new.tsx
@@ -48,8 +48,8 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
       ) : (
         <NewRequestForm
           documentTypes={documentTypes}
-          onSubmit={handleSubmit}
           team={team}
+          onSubmit={handleSubmit}
         />
       )}
     </Layout>

--- a/src/pages/teams/[teamId]/dashboard/requests/new.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/new.tsx
@@ -13,15 +13,16 @@ import {
 } from '../../../../../gateways/internal-api';
 import { RequestAuthorizer } from '../../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../../services/team-helper';
+import { Team } from '../../../../../domain/team';
 
 type RequestsNewPageProps = {
   documentTypes: DocumentType[];
-  teamId: string;
+  team: Team;
 };
 
 const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
   documentTypes,
-  teamId,
+  team,
   user,
 }) => {
   const [complete, setComplete] = useState(false);
@@ -30,8 +31,6 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
     const gateway = new InternalApiGateway();
     const payload: EvidenceRequestRequest = {
       ...values,
-      // TODO: pass this in from the users chosen service after DES-25
-      serviceRequestedBy: 'Housing benefit',
       userRequestedBy: user?.email,
     };
     await gateway.createEvidenceRequest(payload);
@@ -39,7 +38,7 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
   }, []);
 
   return (
-    <Layout teamId={teamId}>
+    <Layout teamId={team.id}>
       <Head>
         <title>Make a new request</title>
       </Head>
@@ -47,7 +46,11 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
       {complete ? (
         <Paragraph>Thanks!</Paragraph>
       ) : (
-        <NewRequestForm documentTypes={documentTypes} onSubmit={handleSubmit} />
+        <NewRequestForm
+          documentTypes={documentTypes}
+          onSubmit={handleSubmit}
+          team={team}
+        />
       )}
     </Layout>
   );
@@ -66,7 +69,8 @@ export const getServerSideProps = withAuth<RequestsNewPageProps>(
       teamId
     );
 
-    if (!userAuthorizedToViewTeam) {
+    const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
+    if (!userAuthorizedToViewTeam || team === undefined) {
       return {
         redirect: {
           destination: '/teams',
@@ -77,7 +81,7 @@ export const getServerSideProps = withAuth<RequestsNewPageProps>(
 
     const gateway = new EvidenceApiGateway();
     const documentTypes = await gateway.getDocumentTypes();
-    return { props: { documentTypes, teamId } };
+    return { props: { documentTypes, team } };
   }
 );
 


### PR DESCRIPTION
- In new evidence request form provide a drop down list of reasons for the selected team
- Populate dropdown with reasons from JSON
- Pass Reason to EvidenceAPI
- Replace instances of `serviceRequestedBy: 'Housing benefit'` with `serviceRequestedBy: {teamName}`