### PR TITLE
Remove document preview for files other than jpg and png

### DIFF
--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -105,18 +105,31 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
         </div>
       )}
 
-      <h2 className="lbh-heading-h3">Preview</h2>
-
-      <figure className={styles.preview}>
-        <img src={downloadUrl} alt="example" />
-        <figcaption className="lbh-body-s">
-          <strong>{document.extension?.toUpperCase()}</strong>{' '}
-          {humanFileSize(document.fileSizeInBytes)}{' '}
-          <a href={`${downloadUrl}`} className="lbh-link">
-            Download
-          </a>
-        </figcaption>
-      </figure>
+      {console.log(documentSubmission)}
+      {document.extension === 'jpg' ||
+        (document.extension === 'png' ? (
+          <>
+            <h2 className="lbh-heading-h3">Preview</h2>
+            <figure className={styles.preview}>
+              <img src={downloadUrl} alt="example" />
+              <figcaption className="lbh-body-s">
+                <strong>{document.extension?.toUpperCase()}</strong>{' '}
+                {humanFileSize(document.fileSizeInBytes)}{' '}
+                <a href={`${downloadUrl}`} className="lbh-link">
+                  Download
+                </a>
+              </figcaption>
+            </figure>
+          </>
+        ) : (
+          <figcaption className="lbh-body-s">
+            <strong>{document.extension?.toUpperCase()}</strong>{' '}
+            {humanFileSize(document.fileSizeInBytes)}{' '}
+            <a href={`${downloadUrl}`} className="lbh-link">
+              Download
+            </a>
+          </figcaption>
+        ))}
 
       {/* https://hackney.atlassian.net/browse/DES-63 */}
       {/* <h2 className="lbh-heading-h3">History</h2> */}


### PR DESCRIPTION
- Removed document preview for files other than jpg and png to make the UI look better when another type of document is uploaded