### PR TITLE
DES-175: Call EvidenceApiGateway.createDocumentSubmission for each file that the resident provides

### DIFF
--- a/cypress/integration/upload-a-document.spec.ts
+++ b/cypress/integration/upload-a-document.spec.ts
@@ -56,7 +56,38 @@ describe('Can upload a document', () => {
       cy.wait('@patch-document-state');
 
       // View confirmation
-      cy.get('h1').should('contain', "We've recieved your documents");
+      cy.get('h1').should('contain', "We've received your documents");
+      cy.get('p').should('contain', `Your reference number: ${requestId}`);
+    });
+
+    it('shows guidance and lets you upload multiple files for each document type', () => {
+      // View guidance
+      cy.get('h1').should(
+        'contain',
+        'You’ll need to photograph your documents'
+      );
+      cy.get('a').contains('Continue').click();
+
+      // Attach a file
+      cy.get('h1').should('contain', 'Upload your documents');
+      cy.get('input[type=file]').each((input) => {
+        cy.wrap(input).attachFile('example.png').attachFile('example.png');
+      });
+      cy.get('button').contains('Continue').click();
+
+      cy.get('button').contains('Continue').should('have.attr', 'disabled');
+
+      cy.wait('@s3Upload');
+      cy.wait('@s3Upload');
+      cy.wait('@s3Upload');
+      cy.wait('@s3Upload');
+      cy.wait('@patch-document-state');
+      cy.wait('@patch-document-state');
+      cy.wait('@patch-document-state');
+      cy.wait('@patch-document-state');
+
+      // View confirmation
+      cy.get('h1').should('contain', "We've received your documents");
       cy.get('p').should('contain', `Your reference number: ${requestId}`);
     });
   });

--- a/src/components/UploaderForm.test.tsx
+++ b/src/components/UploaderForm.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import UploaderForm from './UploaderForm';
 import { ResponseMapper } from '../boundary/response-mapper';
-import DocumentSubmissionFixture from '../../cypress/fixtures/document_submissions/create.json';
+import DocumentTypesFixture from '../../cypress/fixtures/document_types/index.json';
 import * as MockUploadFormModelImport from '../services/__mocks__/upload-form-model';
 import * as UploadFormModelImport from '../services/upload-form-model';
 
@@ -16,9 +16,7 @@ const {
 
 jest.mock('../services/upload-form-model');
 
-const documentSubmissions = [
-  ResponseMapper.mapDocumentSubmission(DocumentSubmissionFixture),
-];
+const documentTypes = DocumentTypesFixture.map(ResponseMapper.mapDocumentType);
 
 const attachFile = (label: string) => {
   const file = new File(['dummy content'], 'example.png', {
@@ -35,7 +33,8 @@ describe('UploaderForm', () => {
   beforeEach(() => {
     render(
       <UploaderForm
-        submissions={documentSubmissions}
+        evidenceRequestId={'123'}
+        documentTypes={documentTypes}
         onSuccess={successHandler}
       />
     );
@@ -48,7 +47,7 @@ describe('UploaderForm', () => {
   });
 
   it('creates a form model with the correct attributes', () => {
-    expect(UploadFormModel).toHaveBeenCalledWith(documentSubmissions);
+    expect(UploadFormModel).toHaveBeenCalledWith(documentTypes);
   });
 
   it('disables the button when submitting', async () => {

--- a/src/components/UploaderForm.test.tsx
+++ b/src/components/UploaderForm.test.tsx
@@ -61,15 +61,18 @@ describe('UploaderForm', () => {
     });
   });
 
-  it('validates files are attached', async () => {
+  it('validates at least one file is attached to each UploaderPanel', async () => {
     submitForm();
     await waitFor(() => {
-      expect(screen.getByText('Please select a file'));
+      // we have 3 DocumentTypes so there should be as many warning messages printed
+      expect(screen.getAllByText('Please select a file').length).toEqual(3);
     });
   });
 
   it('calls submit handler on form model', async () => {
     attachFile('Passport');
+    attachFile('Driving license');
+    attachFile('Bank statement');
     submitForm();
 
     await waitFor(() => {
@@ -82,6 +85,8 @@ describe('UploaderForm', () => {
       throw new Error('oh no');
     });
     attachFile('Passport');
+    attachFile('Driving license');
+    attachFile('Bank statement');
     submitForm();
 
     await waitFor(() => {
@@ -92,6 +97,8 @@ describe('UploaderForm', () => {
   it('calls success callback when upload completes', async () => {
     mockHandleSubmit.mockResolvedValue(true);
     attachFile('Passport');
+    attachFile('Driving license');
+    attachFile('Bank statement');
     submitForm();
 
     await waitFor(() => {

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -18,7 +18,7 @@ const getError = (
   const dirty = touched[id as keyof typeof touched];
   if (!dirty) return null;
   if (errors) return null;
-  //return errors[id as keyof typeof errors] as string;
+  return errors[id as keyof typeof errors] as string;
 };
 
 const UploaderForm: FunctionComponent<Props> = ({

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -7,27 +7,34 @@ import React, {
 import { Button, ErrorMessage } from 'lbh-frontend-react';
 import { Formik, Form, FormikTouched, FormikErrors } from 'formik';
 import UploaderPanel from './UploaderPanel';
-import { DocumentSubmission } from '../domain/document-submission';
-import { UploadFormModel } from '../services/upload-form-model';
+import { FormValues, UploadFormModel } from '../services/upload-form-model';
+import { DocumentType } from '../domain/document-type';
 
 const getError = (
   id: string,
-  touched: FormikTouched<File>,
-  errors: FormikErrors<File>
+  touched: FormikTouched<FormValues>,
+  errors: FormikErrors<FormValues>
 ) => {
   const dirty = touched[id as keyof typeof touched];
   if (!dirty) return null;
-  return errors[id as keyof typeof errors] as string;
+  if (errors) return null;
+  //return errors[id as keyof typeof errors] as string;
 };
 
-const UploaderForm: FunctionComponent<Props> = ({ submissions, onSuccess }) => {
+const UploaderForm: FunctionComponent<Props> = ({
+  evidenceRequestId,
+  documentTypes,
+  onSuccess,
+}) => {
   const [submitError, setSubmitError] = useState(false);
-  const model = useMemo(() => new UploadFormModel(submissions), [submissions]);
+  const model = useMemo(() => new UploadFormModel(documentTypes), [
+    documentTypes,
+  ]);
 
   const handleSubmit = useCallback(
     async (values) => {
       try {
-        await model.handleSubmit(values);
+        await model.handleSubmit(values, evidenceRequestId);
         onSuccess();
       } catch (err) {
         console.log(err);
@@ -51,15 +58,15 @@ const UploaderForm: FunctionComponent<Props> = ({ submissions, onSuccess }) => {
             </ErrorMessage>
           )}
 
-          {submissions.map(({ id, documentType }) => (
+          {documentTypes.map((documentType) => (
             <UploaderPanel
               setFieldValue={setFieldValue}
-              key={id}
+              key={documentType.id}
               label={documentType.title}
               hint={documentType.description}
-              name={id}
-              set={!!values[id as keyof typeof values]}
-              error={getError(id, touched, errors)}
+              name={documentType.id}
+              set={!!values[documentType.id as keyof typeof values]}
+              error={getError(documentType.id, touched, errors)}
             />
           ))}
 
@@ -73,7 +80,8 @@ const UploaderForm: FunctionComponent<Props> = ({ submissions, onSuccess }) => {
 };
 
 interface Props {
-  submissions: DocumentSubmission[];
+  evidenceRequestId: string;
+  documentTypes: DocumentType[];
   onSuccess(): void;
 }
 

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -7,17 +7,16 @@ import React, {
 import { Button, ErrorMessage } from 'lbh-frontend-react';
 import { Formik, Form, FormikTouched, FormikErrors } from 'formik';
 import UploaderPanel from './UploaderPanel';
-import { FormValues, UploadFormModel } from '../services/upload-form-model';
+import { UploadFormModel } from '../services/upload-form-model';
 import { DocumentType } from '../domain/document-type';
 
 const getError = (
   id: string,
-  touched: FormikTouched<FormValues>,
-  errors: FormikErrors<FormValues>
+  touched: FormikTouched<File>,
+  errors: FormikErrors<File>
 ) => {
   const dirty = touched[id as keyof typeof touched];
   if (!dirty) return null;
-  if (errors) return null;
   return errors[id as keyof typeof errors] as string;
 };
 

--- a/src/components/UploaderPanel.tsx
+++ b/src/components/UploaderPanel.tsx
@@ -27,7 +27,7 @@ const UploaderPanel: FunctionComponent<Props> = (props) => (
       accept="image/*,application/pdf"
       onChange={(e) => {
         if (e.currentTarget.files !== null) {
-          props.setFieldValue(props.name, e.currentTarget.files);
+          props.setFieldValue(props.name, Array.from(e.currentTarget.files));
         }
       }}
       aria-describedby={props.hint && `${props.name}-hint`}
@@ -37,7 +37,7 @@ const UploaderPanel: FunctionComponent<Props> = (props) => (
 );
 
 interface Props {
-  setFieldValue(key: string, value: FileList): void;
+  setFieldValue(key: string, value: File[]): void;
   name: string;
   label: string;
   hint?: string;

--- a/src/components/UploaderPanel.tsx
+++ b/src/components/UploaderPanel.tsx
@@ -26,8 +26,9 @@ const UploaderPanel: FunctionComponent<Props> = (props) => (
       data-testid="fileInput"
       accept="image/*,application/pdf"
       onChange={(e) => {
-        if (e.currentTarget.files !== null)
-          props.setFieldValue(props.name, e.currentTarget.files[0]);
+        if (e.currentTarget.files !== null) {
+          props.setFieldValue(props.name, e.currentTarget.files);
+        }
       }}
       aria-describedby={props.hint && `${props.name}-hint`}
       multiple={true}
@@ -36,7 +37,7 @@ const UploaderPanel: FunctionComponent<Props> = (props) => (
 );
 
 interface Props {
-  setFieldValue(key: string, value: File): void;
+  setFieldValue(key: string, value: FileList): void;
   name: string;
   label: string;
   hint?: string;

--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -294,65 +294,65 @@ describe('Evidence api gateway', () => {
     });
   });
 
-  describe('createDocumentSubmission', () => {
-    const documentType = 'passport-scan';
-    const evidenceRequestId = 'evidence request id';
-
-    describe('when there is an error', () => {
-      it('returns internal server error', async () => {
-        client.post.mockRejectedValue(new Error('Internal server error'));
-        const functionCall = () =>
-          gateway.createDocumentSubmission(evidenceRequestId, documentType);
-        await expect(functionCall).rejects.toEqual(
-          new InternalServerError('Internal server error')
-        );
-      });
-    });
-
-    describe('when successful', () => {
-      const mappedResponse = ResponseMapper.mapDocumentSubmission(
-        DocumentSubmissionFixture
-      );
-
-      beforeEach(() => {
-        client.post.mockResolvedValue({ data: DocumentSubmissionFixture });
-        mockedResponseMapper.mapDocumentSubmission.mockReturnValue(
-          mappedResponse
-        );
-      });
-
-      it('calls axios correctly', async () => {
-        await gateway.createDocumentSubmission(evidenceRequestId, documentType);
-        expect(client.post).toHaveBeenCalledWith(
-          `/api/v1/evidence_requests/${evidenceRequestId}/document_submissions`,
-          {
-            documentType,
-          },
-          {
-            headers: {
-              Authorization:
-                process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_POST,
-            },
-          }
-        );
-      });
-
-      it('maps the response correctly', async () => {
-        await gateway.createDocumentSubmission(evidenceRequestId, documentType);
-        expect(mockedResponseMapper.mapDocumentSubmission).toHaveBeenCalledWith(
-          DocumentSubmissionFixture
-        );
-      });
-
-      it('returns the correct response', async () => {
-        const result = await gateway.createDocumentSubmission(
-          evidenceRequestId,
-          documentType
-        );
-        expect(result).toEqual(mappedResponse);
-      });
-    });
-  });
+  // describe('createDocumentSubmission', () => {
+  //   const documentType = 'passport-scan';
+  //   const evidenceRequestId = 'evidence request id';
+  //
+  //   describe('when there is an error', () => {
+  //     it('returns internal server error', async () => {
+  //       client.post.mockRejectedValue(new Error('Internal server error'));
+  //       const functionCall = () =>
+  //         gateway.createDocumentSubmission(evidenceRequestId, documentType);
+  //       await expect(functionCall).rejects.toEqual(
+  //         new InternalServerError('Internal server error')
+  //       );
+  //     });
+  //   });
+  //
+  //   describe('when successful', () => {
+  //     const mappedResponse = ResponseMapper.mapDocumentSubmission(
+  //       DocumentSubmissionFixture
+  //     );
+  //
+  //     beforeEach(() => {
+  //       client.post.mockResolvedValue({ data: DocumentSubmissionFixture });
+  //       mockedResponseMapper.mapDocumentSubmission.mockReturnValue(
+  //         mappedResponse
+  //       );
+  //     });
+  //
+  //     it('calls axios correctly', async () => {
+  //       await gateway.createDocumentSubmission(evidenceRequestId, documentType);
+  //       expect(client.post).toHaveBeenCalledWith(
+  //         `/api/v1/evidence_requests/${evidenceRequestId}/document_submissions`,
+  //         {
+  //           documentType,
+  //         },
+  //         {
+  //           headers: {
+  //             Authorization:
+  //               process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_POST,
+  //           },
+  //         }
+  //       );
+  //     });
+  //
+  //     it('maps the response correctly', async () => {
+  //       await gateway.createDocumentSubmission(evidenceRequestId, documentType);
+  //       expect(mockedResponseMapper.mapDocumentSubmission).toHaveBeenCalledWith(
+  //         DocumentSubmissionFixture
+  //       );
+  //     });
+  //
+  //     it('returns the correct response', async () => {
+  //       const result = await gateway.createDocumentSubmission(
+  //         evidenceRequestId,
+  //         documentType
+  //       );
+  //       expect(result).toEqual(mappedResponse);
+  //     });
+  //   });
+  // });
 
   describe('updateDocumentSubmission', () => {
     const documentSubmissionId = 'document submission id';

--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -294,66 +294,6 @@ describe('Evidence api gateway', () => {
     });
   });
 
-  // describe('createDocumentSubmission', () => {
-  //   const documentType = 'passport-scan';
-  //   const evidenceRequestId = 'evidence request id';
-  //
-  //   describe('when there is an error', () => {
-  //     it('returns internal server error', async () => {
-  //       client.post.mockRejectedValue(new Error('Internal server error'));
-  //       const functionCall = () =>
-  //         gateway.createDocumentSubmission(evidenceRequestId, documentType);
-  //       await expect(functionCall).rejects.toEqual(
-  //         new InternalServerError('Internal server error')
-  //       );
-  //     });
-  //   });
-  //
-  //   describe('when successful', () => {
-  //     const mappedResponse = ResponseMapper.mapDocumentSubmission(
-  //       DocumentSubmissionFixture
-  //     );
-  //
-  //     beforeEach(() => {
-  //       client.post.mockResolvedValue({ data: DocumentSubmissionFixture });
-  //       mockedResponseMapper.mapDocumentSubmission.mockReturnValue(
-  //         mappedResponse
-  //       );
-  //     });
-  //
-  //     it('calls axios correctly', async () => {
-  //       await gateway.createDocumentSubmission(evidenceRequestId, documentType);
-  //       expect(client.post).toHaveBeenCalledWith(
-  //         `/api/v1/evidence_requests/${evidenceRequestId}/document_submissions`,
-  //         {
-  //           documentType,
-  //         },
-  //         {
-  //           headers: {
-  //             Authorization:
-  //               process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_POST,
-  //           },
-  //         }
-  //       );
-  //     });
-  //
-  //     it('maps the response correctly', async () => {
-  //       await gateway.createDocumentSubmission(evidenceRequestId, documentType);
-  //       expect(mockedResponseMapper.mapDocumentSubmission).toHaveBeenCalledWith(
-  //         DocumentSubmissionFixture
-  //       );
-  //     });
-  //
-  //     it('returns the correct response', async () => {
-  //       const result = await gateway.createDocumentSubmission(
-  //         evidenceRequestId,
-  //         documentType
-  //       );
-  //       expect(result).toEqual(mappedResponse);
-  //     });
-  //   });
-  // });
-
   describe('updateDocumentSubmission', () => {
     const documentSubmissionId = 'document submission id';
     const apiResponse = {} as DocumentSubmissionResponse;

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -95,23 +95,6 @@ export class EvidenceApiGateway {
     }
   }
 
-  async createDocumentSubmission(
-    evidenceRequestId: string,
-    documentType: string
-  ): Promise<DocumentSubmission> {
-    try {
-      const { data } = await this.client.post<DocumentSubmissionResponse>(
-        `/api/v1/evidence_requests/${evidenceRequestId}/document_submissions`,
-        { documentType },
-        { headers: { Authorization: tokens?.evidence_requests?.POST } }
-      );
-      return ResponseMapper.mapDocumentSubmission(data);
-    } catch (err) {
-      console.error(err);
-      throw new InternalServerError('Internal server error');
-    }
-  }
-
   async updateDocumentSubmission(
     documentSubmissionId: string,
     params: Partial<IDocumentSubmission>

--- a/src/gateways/internal-api.test.ts
+++ b/src/gateways/internal-api.test.ts
@@ -5,7 +5,11 @@ import {
   DocumentState,
   DocumentSubmission,
 } from '../domain/document-submission';
-import { EvidenceRequestRequest, InternalApiGateway, InternalServerError } from './internal-api';
+import {
+  EvidenceRequestRequest,
+  InternalApiGateway,
+  InternalServerError,
+} from './internal-api';
 import { Resident } from '../domain/resident';
 import { EvidenceRequest } from '../domain/evidence-request';
 
@@ -151,9 +155,7 @@ describe('Internal API Gateway', () => {
           data: apiResponse,
         });
 
-        mockedResponseMapper.mapEvidenceRequest.mockReturnValue(
-          expectedResult
-        );
+        mockedResponseMapper.mapEvidenceRequest.mockReturnValue(expectedResult);
       });
 
       it('makes the api request', async () => {
@@ -175,8 +177,7 @@ describe('Internal API Gateway', () => {
     describe('when there is an error', () => {
       it('returns internal server error', async () => {
         client.post.mockRejectedValue(new Error('Internal server error'));
-        const functionCall = () =>
-          gateway.createEvidenceRequest(baseRequest);
+        const functionCall = () => gateway.createEvidenceRequest(baseRequest);
         await expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -60,6 +60,22 @@ export class InternalApiGateway {
     }
   }
 
+  async createDocumentSubmission(
+    evidenceRequestId: string,
+    documentType: string
+  ): Promise<DocumentSubmission> {
+    try {
+      const { data } = await this.client.post<DocumentSubmissionResponse>(
+        `/api/evidence/evidence_requests/${evidenceRequestId}/document_submissions`,
+        { documentType }
+      );
+      return ResponseMapper.mapDocumentSubmission(data);
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerError('Internal server error');
+    }
+  }
+
   async updateDocumentSubmission(
     documentSubmissionId: string,
     params: Partial<IDocumentSubmission>

--- a/src/pages/resident/[requestId]/confirmation.tsx
+++ b/src/pages/resident/[requestId]/confirmation.tsx
@@ -18,7 +18,7 @@ const Index = (): ReactNode => {
         <div className="govuk-grid-column-two-thirds">
           <Panel>
             <Heading level={HeadingLevels.H1}>
-              We've recieved your documents
+              We've received your documents
             </Heading>
             <p className="lbh-body">Your reference number: {requestId}</p>
           </Panel>

--- a/src/pages/resident/[requestId]/upload.tsx
+++ b/src/pages/resident/[requestId]/upload.tsx
@@ -3,17 +3,22 @@ import { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
-import { DocumentSubmission } from 'src/domain/document-submission';
+import { DocumentType } from '../../../domain/document-type';
 import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import Layout from '../../../components/ResidentLayout';
 import UploaderForm from '../../../components/UploaderForm';
 
 type UploadProps = {
-  documentSubmissions: DocumentSubmission[];
   requestId: string;
+  evidenceRequestId: string;
+  documentTypes: DocumentType[];
 };
 
-const Upload: NextPage<UploadProps> = ({ documentSubmissions, requestId }) => {
+const Upload: NextPage<UploadProps> = ({
+  requestId,
+  evidenceRequestId,
+  documentTypes,
+}) => {
   const router = useRouter();
   const onSuccess = useCallback(() => {
     router.push(`/resident/${requestId}/confirmation`);
@@ -27,14 +32,14 @@ const Upload: NextPage<UploadProps> = ({ documentSubmissions, requestId }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <Heading level={HeadingLevels.H1}>
-            Upload your{' '}
-            {documentSubmissions?.length > 1 ? 'documents' : 'document'}
+            Upload your {documentTypes?.length > 1 ? 'documents' : 'document'}
           </Heading>
           <p className="lbh-body">
             Upload a photograph or scan for the following evidence.
           </p>
           <UploaderForm
-            submissions={documentSubmissions}
+            evidenceRequestId={evidenceRequestId}
+            documentTypes={documentTypes}
             onSuccess={onSuccess}
           />
         </div>
@@ -52,15 +57,11 @@ export const getServerSideProps: GetServerSideProps<
 
   const gateway = new EvidenceApiGateway();
   const evidenceRequest = await gateway.getEvidenceRequest(requestId);
-
-  const requests = evidenceRequest.documentTypes.map(({ id }) =>
-    gateway.createDocumentSubmission(evidenceRequest.id, id)
-  );
-
-  const documentSubmissions = await Promise.all(requests);
+  const evidenceRequestId = evidenceRequest.id;
+  const documentTypes = evidenceRequest.documentTypes;
 
   return {
-    props: { requestId, documentSubmissions },
+    props: { requestId, evidenceRequestId, documentTypes },
   };
 };
 

--- a/src/services/__mocks__/upload-form-model.ts
+++ b/src/services/__mocks__/upload-form-model.ts
@@ -1,4 +1,4 @@
-import { DocumentSubmission } from 'src/domain/document-submission';
+import { FormValues } from '../upload-form-model';
 
 const { UploadFormModel: ActualFormModel } = jest.requireActual(
   '../upload-form-model'
@@ -6,8 +6,8 @@ const { UploadFormModel: ActualFormModel } = jest.requireActual(
 
 export const mockHandleSubmit = jest.fn();
 export const UploadFormModel = jest.fn(
-  (id: string, submissions: DocumentSubmission[]) => {
-    const model = new ActualFormModel(id, submissions);
+  (formValues: FormValues, evidenceRequestId: string) => {
+    const model = new ActualFormModel(formValues, evidenceRequestId);
     model.handleSubmit = mockHandleSubmit;
 
     return model;

--- a/src/services/request-authorizer.ts
+++ b/src/services/request-authorizer.ts
@@ -18,6 +18,7 @@ const AUTH_WHITELIST = [
   '/resident/*/confirmation',
   '/evidence_requests/*',
   '/evidence_requests/*/document_submissions',
+  '/document_submissions/*',
 ].map((str) => new RegExp(`^${str.replace('*', GLOB)}$`));
 
 export interface RequestAuthorizerCommand {

--- a/src/services/upload-form-model.test.ts
+++ b/src/services/upload-form-model.test.ts
@@ -45,7 +45,7 @@ describe('UploadFormModel', () => {
     const fileList1 = [new File(['foo'], 'foo.txt')];
     const fileList2 = [
       new File(['bar'], 'bar.png'),
-      new File(['baz'], 'bax.png'),
+      new File(['baz'], 'baz.png'),
     ];
 
     const values: FormValues = {
@@ -88,7 +88,7 @@ describe('UploadFormModel', () => {
       );
       expect(uploadMock).toHaveBeenNthCalledWith(
         3,
-        fileList2[0],
+        fileList2[1],
         documentSubmission.uploadPolicy
       );
     });

--- a/src/services/upload-form-model.ts
+++ b/src/services/upload-form-model.ts
@@ -8,7 +8,7 @@ import { InternalApiGateway } from '../gateways/internal-api';
 import { DocumentType } from '../domain/document-type';
 
 export type FormValues = {
-  [documentTypeId: string]: FileList;
+  [documentTypeId: string]: File[];
 };
 
 class FileDocumentSubmission {
@@ -77,8 +77,8 @@ export class UploadFormModel {
     evidenceRequestId: string
   ): Promise<FileDocumentSubmission[]> {
     const fileDocumentSubmissions: FileDocumentSubmission[] = [];
-    for (const [documentTypeId, fileList] of Object.entries(formValues)) {
-      for (const file of Array.from(fileList)) {
+    for (const [documentTypeId, files] of Object.entries(formValues)) {
+      for (const file of files) {
         const documentSubmission = await this.gateway.createDocumentSubmission(
           evidenceRequestId,
           documentTypeId


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-175

- Call `EvidenceApiGateway.createDocumentSubmission` for each file that the resident provides
  - Move calling `createDocumentSubmission` from `upload` to `upload-form-model`
  - This meant moving `createDocumentSubmission` from `evidence-api` to `internal-api`