### PR TITLE
DES-170: show timestamp associated with each document submission

### DIFF
--- a/src/boundary/response-mapper.test.ts
+++ b/src/boundary/response-mapper.test.ts
@@ -58,7 +58,11 @@ describe('ResponseMapper', () => {
         year: 2020,
         month: 11,
         day: 30,
+        hour: 15,
+        minute: 34,
+        second: 12,
       });
+      expect(result.createdAt.zoneName).toEqual('UTC');
     });
 
     it('maps the resident', () => {
@@ -103,7 +107,11 @@ describe('ResponseMapper', () => {
         year: 2021,
         month: 1,
         day: 14,
+        hour: 10,
+        minute: 23,
+        second: 42,
       });
+      expect(result.createdAt.zoneName).toEqual('UTC');
     });
 
     it('maps the document state', () => {

--- a/src/boundary/response-mapper.ts
+++ b/src/boundary/response-mapper.ts
@@ -17,7 +17,7 @@ import { Document } from 'src/domain/document';
 export class ResponseMapper {
   static mapEvidenceRequest(attrs: EvidenceRequestResponse): EvidenceRequest {
     const resident = new Resident(attrs.resident);
-    const createdAt = DateTime.fromISO(attrs.createdAt);
+    const createdAt = DateTime.fromISO(attrs.createdAt, { zone: 'utc' });
     const deliveryMethods = attrs.deliveryMethods.map(
       (dm) => DeliveryMethod[dm as keyof typeof DeliveryMethod]
     );
@@ -39,7 +39,7 @@ export class ResponseMapper {
   static mapDocumentSubmission(
     attrs: DocumentSubmissionResponse
   ): DocumentSubmission {
-    const createdAt = DateTime.fromISO(attrs.createdAt);
+    const createdAt = DateTime.fromISO(attrs.createdAt, { zone: 'utc' });
     const state = DocumentState[attrs.state as keyof typeof DocumentState];
     const documentType = new DocumentType(attrs.documentType);
     const staffSelectedDocumentType = attrs.staffSelectedDocumentType

--- a/src/helpers/formatters.test.ts
+++ b/src/helpers/formatters.test.ts
@@ -1,9 +1,20 @@
-import { humanFileSize } from './formatters';
+import { formatDate, humanFileSize } from './formatters';
+import { DateTime } from 'luxon';
 
 describe('File size helper', () => {
   it('returns correct strings with the right number of decimal places', () => {
     expect(humanFileSize(0)).toEqual('0.0 B');
     expect(humanFileSize(1024)).toEqual('1.0 KB');
     expect(humanFileSize(1073741824)).toEqual('1.0 GB');
+  });
+});
+
+describe('Format date helper', () => {
+  it('returns the correctly formatted', () => {
+    const formattedDate = formatDate(
+      DateTime.local(2021, 4, 14, 18, 21).setLocale('en-gb')
+    );
+    // do not compare the second part of the formatted date because it contains relative days so will change
+    expect(formattedDate.substr(0, 19)).toEqual('18:21 14 April 2021');
   });
 });

--- a/src/helpers/formatters.ts
+++ b/src/helpers/formatters.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon';
+
 export const humanFileSize = (bytes: number): string => {
   if (bytes == 0) {
     return '0.0 B';
@@ -5,5 +7,15 @@ export const humanFileSize = (bytes: number): string => {
   const e = Math.floor(Math.log(bytes) / Math.log(1024));
   return (
     (bytes / Math.pow(1024, e)).toFixed(1) + ' ' + ' KMGTP'.charAt(e) + 'B'
+  );
+};
+
+// For example: 14:15 5 Jun 2020 (2 days ago)
+export const formatDate = (dateTime: DateTime): string => {
+  return (
+    dateTime.toLocal().toFormat('t d LLLL y') +
+    ' (' +
+    dateTime.toRelativeCalendar() +
+    ')'
   );
 };

--- a/src/helpers/register-domain.ts
+++ b/src/helpers/register-domain.ts
@@ -20,7 +20,7 @@ export const registerDomainModels = (): void => {
       {
         isApplicable: (v): v is DateTime => v instanceof DateTime,
         serialize: (v) => v.toISO(),
-        deserialize: (v) => DateTime.fromISO(v),
+        deserialize: (v) => DateTime.fromISO(v, { zone: 'utc' }),
       },
       'datetime'
     );

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
@@ -7,9 +7,9 @@ import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { Resident } from 'src/domain/resident';
 import { EvidenceList, EvidenceTile } from 'src/components/EvidenceTile';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
-// import styles from 'src/styles/Resident.module.scss';
 import { RequestAuthorizer } from '../../../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../../../services/team-helper';
+import { formatDate } from '../../../../../../helpers/formatters';
 
 type ResidentPageProps = {
   documentSubmissions: DocumentSubmission[];
@@ -29,9 +29,6 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
   const toReviewDocumentSubmissions = documentSubmissions.filter(
     (ds) => ds.state == 'UPLOADED'
   );
-  // const pendingDocumentSubmissions = documentSubmissions.filter(
-  //   (ds) => ds.state == 'PENDING'
-  // );
   const reviewedDocumentSubmissions = documentSubmissions.filter(
     (ds) => ds.state == 'APPROVED'
   );
@@ -47,6 +44,7 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
 
       <div className="toReview">
         <h2 className="lbh-heading-h3">To review</h2>
+
         <EvidenceList>
           {toReviewDocumentSubmissions &&
           toReviewDocumentSubmissions.length > 0 ? (
@@ -57,7 +55,7 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
                 key={ds.id}
                 id={ds.id}
                 title={String(ds.documentType.title)}
-                createdAt={String(ds.createdAt.toRelativeCalendar())}
+                createdAt={formatDate(ds.createdAt)}
                 fileSizeInBytes={ds.document ? ds.document.fileSizeInBytes : 0}
                 format={ds.document ? ds.document.extension : 'unknown'}
                 // purpose="Example form"
@@ -69,43 +67,6 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
           )}
         </EvidenceList>
       </div>
-
-      {/* <h2 className="lbh-heading-h3">Pending requests</h2>
-
-      {pendingDocumentSubmissions && pendingDocumentSubmissions.length > 0 ? (
-        <>
-          <table className={`govuk-table lbh-table ${styles.table}`}>
-            <thead className="govuk-table__head">
-              <tr className="govuk-table__row">
-                <th scope="col" className="govuk-table__header">
-                  Document
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  Requested
-                </th>
-                <th scope="col" className="govuk-table__header">
-                  <span className="lbu-visually-hidden">Actions</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody className="govuk-table__body">
-              {pendingDocumentSubmissions.map((ds) => (
-                <tr className="govuk-table__row">
-                  <td className="govuk-table__cell">{ds.documentType.title}</td>
-                  <td className="govuk-table__cell">
-                    {ds.createdAt.toRelativeCalendar()}
-                  </td>
-                  <td className="govuk-table__cell  govuk-table__cell--numeric">
-                    <Button className={styles.button}>Remind</Button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </>
-      ) : (
-        <h4>There are no pending documents</h4>
-      )} */}
 
       <div className="reviewed">
         <h2 className="lbh-heading-h3">Reviewed</h2>
@@ -120,7 +81,7 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
                 key={ds.id}
                 id={ds.id}
                 title={String(ds.staffSelectedDocumentType?.title)}
-                createdAt={String(ds.createdAt.toRelativeCalendar())}
+                createdAt={formatDate(ds.createdAt)}
                 fileSizeInBytes={ds.document ? ds.document.fileSizeInBytes : 0}
                 format={ds.document ? ds.document.extension : 'unknown'}
                 // purpose="Example form"

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
@@ -7,6 +7,7 @@ import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { Resident } from 'src/domain/resident';
 import { EvidenceList, EvidenceTile } from 'src/components/EvidenceTile';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
+// import styles from 'src/styles/Resident.module.scss';
 import { RequestAuthorizer } from '../../../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../../../services/team-helper';
 import { formatDate } from '../../../../../../helpers/formatters';
@@ -29,6 +30,9 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
   const toReviewDocumentSubmissions = documentSubmissions.filter(
     (ds) => ds.state == 'UPLOADED'
   );
+  // const pendingDocumentSubmissions = documentSubmissions.filter(
+  //   (ds) => ds.state == 'PENDING'
+  // );
   const reviewedDocumentSubmissions = documentSubmissions.filter(
     (ds) => ds.state == 'APPROVED'
   );
@@ -67,6 +71,43 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
           )}
         </EvidenceList>
       </div>
+
+      {/* <h2 className="lbh-heading-h3">Pending requests</h2>
+
+      {pendingDocumentSubmissions && pendingDocumentSubmissions.length > 0 ? (
+        <>
+          <table className={`govuk-table lbh-table ${styles.table}`}>
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th scope="col" className="govuk-table__header">
+                  Document
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Requested
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  <span className="lbu-visually-hidden">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {pendingDocumentSubmissions.map((ds) => (
+                <tr className="govuk-table__row">
+                  <td className="govuk-table__cell">{ds.documentType.title}</td>
+                  <td className="govuk-table__cell">
+                    {ds.createdAt.toRelativeCalendar()}
+                  </td>
+                  <td className="govuk-table__cell  govuk-table__cell--numeric">
+                    <Button className={styles.button}>Remind</Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      ) : (
+        <h4>There are no pending documents</h4>
+      )} */}
 
       <div className="reviewed">
         <h2 className="lbh-heading-h3">Reviewed</h2>


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-170

- Display dates in the format _14:15 5 Jun 2020 (2 days ago)_
- Ensure Luxon `DateTime` are always created as UTC because they are stored in the database in this timezone (see https://hackney.atlassian.net/browse/DES-204)
  - This means whenever `toLocal()` is called then they are adjusted into the user's timezone