### PR TITLE
Add mock server behaviour for approved document and cypress test

### DIFF
--- a/cypress/fixtures/document_submissions/get-approved.json
+++ b/cypress/fixtures/document_submissions/get-approved.json
@@ -1,0 +1,18 @@
+{
+  "documentType": {
+    "id": "proof-of-id",
+    "title": "Proof of ID",
+    "description": "A valid document that can be used to prove identity"
+  },
+  "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+  "createdAt": "2021-01-14T10:23:42.958Z",
+  "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+  "rejectionReason": "string",
+  "state": "APPROVED",
+  "document": {
+    "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+    "createdAt": "2021-01-29T16:28:11.326Z",
+    "fileSize": 25300,
+    "fileType": "image/png"
+  }
+}

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -124,6 +124,11 @@ describe('Can view and manage evidence', () => {
       rejectionReason: 'some rejection reason',
     });
   });
+
+  it('can copy the page URL using button', () => {
+    cy.get('.reviewed a').contains('Proof of ID').click();
+    cy.get('button').contains('Copy page URL');
+  });
 });
 
 export {};

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -125,7 +125,7 @@ describe('Can view and manage evidence', () => {
     });
   });
 
-  it('can copy the page URL using button', () => {
+  it('can view approved documents', () => {
     cy.get('.reviewed a').contains('Proof of ID').click();
     cy.get('button').contains('Copy page URL');
   });

--- a/test/mocks/behaviours.json
+++ b/test/mocks/behaviours.json
@@ -10,6 +10,7 @@
       "create-document-submission",
       "get-document-submission-png",
       "get-document-submission-pdf",
+      "get-approved-document-submission-png",
       "update-document-submission",
       "get-residents",
       "get-document-submissions-with-resident",

--- a/test/mocks/fixtures/document-submissions.js
+++ b/test/mocks/fixtures/document-submissions.js
@@ -1,5 +1,6 @@
 const documentSubmissionPng = require('../../../cypress/fixtures/document_submissions/get-png.json');
 const documentSubmissionPdf = require('../../../cypress/fixtures/document_submissions/get-pdf.json');
+const approvedDocumentSubmission = require('../../../cypress/fixtures/document_submissions/get-approved.json');
 const documentSubmissionsWithResident = require('../../../cypress/fixtures/document_submissions/get-many.json');
 
 // There may be a neater way of doing this with MocksServer variants but I couldn't get it to work.
@@ -11,6 +12,16 @@ const getDocumentSubmissionPng = {
   response: {
     status: 200,
     body: documentSubmissionPng,
+  },
+};
+
+const getApprovedDocumentSubmissionPng = {
+  id: 'get-approved-document-submission-png',
+  url: '/api/v1/document_submissions/c82120d2-0a5c-4f40-bdcd-5a18d8773446',
+  method: 'GET',
+  response: {
+    status: 200,
+    body: approvedDocumentSubmission,
   },
 };
 
@@ -51,4 +62,5 @@ module.exports = {
   getDocumentSubmissionPng,
   getDocumentSubmissionPdf,
   getDocumentSubmissionWithResident,
+  getApprovedDocumentSubmissionPng,
 };


### PR DESCRIPTION
Added a new behaviour to the mock server for the approved document
Added a cypress test for the copy to clipboard button (functionality can't be tested in the dev environment as it only works in https)