### PR TITLE
DES-276: Update API calls from Frontend to include user email

### DIFF
--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -95,13 +95,11 @@ describe('Can view and manage evidence', () => {
 
       cy.get('button').contains('Yes, accept').click();
 
-      cy.get('@updateDocumentState')
-        .its('request.body.params')
-        .should('deep.equal', {
-          state: 'APPROVED',
-          staffSelectedDocumentTypeId: 'passport-scan',
-          validUntil: '30-4-2022',
-        });
+      cy.get('@updateDocumentState').its('request.body').should('deep.equal', {
+        state: 'APPROVED',
+        staffSelectedDocumentTypeId: 'passport-scan',
+        validUntil: '30-4-2022',
+      });
     });
 
     cy.get('[role=dialog]').should('not.exist');
@@ -121,12 +119,10 @@ describe('Can view and manage evidence', () => {
       cy.get('textarea').type('some rejection reason');
       cy.get('button').contains('Request new file').click();
     });
-    cy.get('@updateDocumentState')
-      .its('request.body.params')
-      .should('deep.equal', {
-        state: 'REJECTED',
-        rejectionReason: 'some rejection reason',
-      });
+    cy.get('@updateDocumentState').its('request.body').should('deep.equal', {
+      state: 'REJECTED',
+      rejectionReason: 'some rejection reason',
+    });
   });
 
   it('can view approved documents', () => {

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -95,11 +95,13 @@ describe('Can view and manage evidence', () => {
 
       cy.get('button').contains('Yes, accept').click();
 
-      cy.get('@updateDocumentState').its('request.body').should('deep.equal', {
-        state: 'APPROVED',
-        staffSelectedDocumentTypeId: 'passport-scan',
-        validUntil: '30-4-2022',
-      });
+      cy.get('@updateDocumentState')
+        .its('request.body.params')
+        .should('deep.equal', {
+          state: 'APPROVED',
+          staffSelectedDocumentTypeId: 'passport-scan',
+          validUntil: '30-4-2022',
+        });
     });
 
     cy.get('[role=dialog]').should('not.exist');
@@ -119,10 +121,12 @@ describe('Can view and manage evidence', () => {
       cy.get('textarea').type('some rejection reason');
       cy.get('button').contains('Request new file').click();
     });
-    cy.get('@updateDocumentState').its('request.body').should('deep.equal', {
-      state: 'REJECTED',
-      rejectionReason: 'some rejection reason',
-    });
+    cy.get('@updateDocumentState')
+      .its('request.body.params')
+      .should('deep.equal', {
+        state: 'REJECTED',
+        rejectionReason: 'some rejection reason',
+      });
   });
 
   it('can view approved documents', () => {

--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -54,7 +54,9 @@ describe('Evidence api gateway', () => {
     });
 
     it('the request returns the correct response', async () => {
-      const response = await gateway.request(path, method);
+      const response = await gateway.request(path, method, {
+        useremail: Constants.DUMMY_EMAIL, // this is lowercase here because All HTTP header keys are converted to lowercase in both directions
+      });
       expect(response).toEqual(expectedResponse);
       expect(client.request).toHaveBeenCalledWith({
         method,
@@ -63,6 +65,7 @@ describe('Evidence api gateway', () => {
         validateStatus,
         headers: {
           Authorization: process.env.EVIDENCE_API_TOKEN_DOCUMENT_TYPES_GET,
+          UserEmail: Constants.DUMMY_EMAIL,
         },
       });
     });
@@ -91,7 +94,9 @@ describe('Evidence api gateway', () => {
     });
 
     it('the request returns the correct response', async () => {
-      const response = await gateway.request(path, method);
+      const response = await gateway.request(path, method, {
+        useremail: Constants.DUMMY_EMAIL,
+      });
       expect(response).toEqual(expectedResponse);
       expect(client.request).toHaveBeenCalledWith({
         method,
@@ -100,6 +105,7 @@ describe('Evidence api gateway', () => {
         validateStatus,
         headers: {
           Authorization: process.env.EVIDENCE_API_TOKEN_DOCUMENT_TYPES_GET,
+          UserEmail: Constants.DUMMY_EMAIL,
         },
       });
     });
@@ -108,6 +114,9 @@ describe('Evidence api gateway', () => {
   describe('POST request to /evidence_requests', () => {
     const path = ['evidence_requests'];
     const method = 'POST';
+    const headers = {
+      useremail: Constants.DUMMY_EMAIL,
+    };
     const body = {
       data: 'bar',
     };
@@ -126,7 +135,7 @@ describe('Evidence api gateway', () => {
     });
 
     it('the request returns the correct response', async () => {
-      const response = await gateway.request(path, method, body);
+      const response = await gateway.request(path, method, headers, body);
       expect(response).toEqual(expectedResponse);
       expect(client.request).toHaveBeenCalledWith({
         method,
@@ -134,6 +143,7 @@ describe('Evidence api gateway', () => {
         data: body,
         headers: {
           Authorization: process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_POST,
+          UserEmail: Constants.DUMMY_EMAIL,
         },
         validateStatus,
       });
@@ -158,7 +168,9 @@ describe('Evidence api gateway', () => {
     });
 
     it('does not throw an error', async () => {
-      const response = await gateway.request(path, method);
+      const response = await gateway.request(path, method, {
+        useremail: Constants.DUMMY_EMAIL,
+      });
       expect(response).toEqual(expectedResponse);
     });
 
@@ -172,7 +184,9 @@ describe('Evidence api gateway', () => {
       });
 
       it('returns status code 500', async () => {
-        const response = await gateway.request(path, method);
+        const response = await gateway.request(path, method, {
+          useremail: Constants.DUMMY_EMAIL,
+        });
         expect(response).toEqual(expectedResponse);
       });
     });
@@ -199,7 +213,9 @@ describe('Evidence api gateway', () => {
     });
 
     it('returns the correct response', async () => {
-      const response = await gateway.request(path, method);
+      const response = await gateway.request(path, method, {
+        useremail: Constants.DUMMY_EMAIL,
+      });
       expect(response).toEqual(expectedResponse);
       expect(client.request).toHaveBeenCalledWith({
         method,
@@ -208,6 +224,7 @@ describe('Evidence api gateway', () => {
         validateStatus,
         headers: {
           Authorization: process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_GET,
+          UserEmail: Constants.DUMMY_EMAIL,
         },
       });
     });

--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -11,6 +11,7 @@ import DocumentSubmissionsFixture from '../../cypress/fixtures/document_submissi
 import EvidenceRequestFixture from '../../cypress/fixtures/evidence_requests/index.json';
 import { EvidenceApiGateway } from './evidence-api';
 import { InternalServerError } from './internal-api';
+import { Constants } from '../helpers/Constants';
 
 jest.mock('../boundary/response-mapper');
 const mockedResponseMapper = ResponseMapper as jest.Mocked<
@@ -234,6 +235,7 @@ describe('Evidence api gateway', () => {
 
       it('calls axios correctly', async () => {
         await gateway.getEvidenceRequests(
+          Constants.DUMMY_EMAIL,
           'Housing benefit',
           EvidenceRequestState.PENDING
         );
@@ -243,6 +245,7 @@ describe('Evidence api gateway', () => {
             headers: {
               Authorization:
                 process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_GET,
+              UserEmail: Constants.DUMMY_EMAIL,
             },
             params: {
               serviceRequestedBy: 'Housing benefit',
@@ -253,7 +256,10 @@ describe('Evidence api gateway', () => {
       });
 
       it('maps the response', async () => {
-        await gateway.getEvidenceRequests('Housing benefit');
+        await gateway.getEvidenceRequests(
+          Constants.DUMMY_EMAIL,
+          'Housing benefit'
+        );
 
         for (let i = 0; i < expectedData.length; i++) {
           expect(
@@ -263,7 +269,10 @@ describe('Evidence api gateway', () => {
       });
 
       it('returns mapped EvidenceTypes', async () => {
-        const result = await gateway.getEvidenceRequests('Housing benefit');
+        const result = await gateway.getEvidenceRequests(
+          Constants.DUMMY_EMAIL,
+          'Housing benefit'
+        );
         expect(result).toEqual(mappedData);
       });
     });
@@ -272,7 +281,7 @@ describe('Evidence api gateway', () => {
       it('returns internal server error', async () => {
         client.get.mockRejectedValue(new Error('Network error'));
         const functionCall = () =>
-          gateway.getEvidenceRequests('Housing benefit');
+          gateway.getEvidenceRequests(Constants.DUMMY_EMAIL, 'Housing benefit');
         expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -295,27 +304,31 @@ describe('Evidence api gateway', () => {
       });
 
       it('calls axios correctly', async () => {
-        await gateway.getEvidenceRequest(id);
+        await gateway.getEvidenceRequest(Constants.DUMMY_EMAIL, id);
         expect(client.get).toHaveBeenLastCalledWith(
           `/api/v1/evidence_requests/${id}`,
           {
             headers: {
               Authorization:
                 process.env.EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_GET,
+              UserEmail: Constants.DUMMY_EMAIL,
             },
           }
         );
       });
 
       it('maps the response', async () => {
-        await gateway.getEvidenceRequest(id);
+        await gateway.getEvidenceRequest(Constants.DUMMY_EMAIL, id);
         expect(mockedResponseMapper.mapEvidenceRequest).toHaveBeenCalledWith(
           expectedData
         );
       });
 
       it('returns mapped EvidenceTypes', async () => {
-        const result = await gateway.getEvidenceRequest(id);
+        const result = await gateway.getEvidenceRequest(
+          Constants.DUMMY_EMAIL,
+          id
+        );
         expect(result).toEqual(mappedData);
       });
     });
@@ -323,7 +336,8 @@ describe('Evidence api gateway', () => {
     describe('when there is an error', () => {
       it('returns internal server error', async () => {
         client.get.mockRejectedValue(new Error('Network error'));
-        const functionCall = () => gateway.getEvidenceRequest(id);
+        const functionCall = () =>
+          gateway.getEvidenceRequest(Constants.DUMMY_EMAIL, id);
         expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -348,9 +362,13 @@ describe('Evidence api gateway', () => {
       });
 
       it('makes the api request', async () => {
-        await gateway.updateDocumentSubmission(documentSubmissionId, {
-          state: DocumentState.UPLOADED,
-        });
+        await gateway.updateDocumentSubmission(
+          Constants.DUMMY_EMAIL,
+          documentSubmissionId,
+          {
+            state: DocumentState.UPLOADED,
+          }
+        );
 
         expect(client.patch).toHaveBeenCalledWith(
           `/api/v1/document_submissions/${documentSubmissionId}`,
@@ -359,6 +377,7 @@ describe('Evidence api gateway', () => {
             headers: {
               Authorization:
                 process.env.EVIDENCE_API_TOKEN_DOCUMENT_SUBMISSIONS_PATCH,
+              UserEmail: Constants.DUMMY_EMAIL,
             },
           }
         );
@@ -366,6 +385,7 @@ describe('Evidence api gateway', () => {
 
       it('returns the updated model', async () => {
         const result = await gateway.updateDocumentSubmission(
+          Constants.DUMMY_EMAIL,
           documentSubmissionId,
           {
             state: DocumentState.UPLOADED,
@@ -380,9 +400,13 @@ describe('Evidence api gateway', () => {
       it('returns internal server error', async () => {
         client.patch.mockRejectedValue(new Error('Internal server error'));
         const functionCall = () =>
-          gateway.updateDocumentSubmission(documentSubmissionId, {
-            state: DocumentState.UPLOADED,
-          });
+          gateway.updateDocumentSubmission(
+            Constants.DUMMY_EMAIL,
+            documentSubmissionId,
+            {
+              state: DocumentState.UPLOADED,
+            }
+          );
         await expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -405,27 +429,31 @@ describe('Evidence api gateway', () => {
       });
 
       it('calls axios correctly', async () => {
-        await gateway.getDocumentSubmission(id);
+        await gateway.getDocumentSubmission(Constants.DUMMY_EMAIL, id);
         expect(client.get).toHaveBeenLastCalledWith(
           `/api/v1/document_submissions/${id}`,
           {
             headers: {
               Authorization:
                 process.env.EVIDENCE_API_TOKEN_DOCUMENT_SUBMISSIONS_GET,
+              UserEmail: Constants.DUMMY_EMAIL,
             },
           }
         );
       });
 
       it('maps the response', async () => {
-        await gateway.getDocumentSubmission(id);
+        await gateway.getDocumentSubmission(Constants.DUMMY_EMAIL, id);
         expect(mockedResponseMapper.mapDocumentSubmission).toHaveBeenCalledWith(
           expectedData
         );
       });
 
       it('returns mapped EvidenceTypes', async () => {
-        const result = await gateway.getDocumentSubmission(id);
+        const result = await gateway.getDocumentSubmission(
+          Constants.DUMMY_EMAIL,
+          id
+        );
         expect(result).toEqual(mappedData);
       });
     });
@@ -433,7 +461,8 @@ describe('Evidence api gateway', () => {
     describe('when there is an error', () => {
       it('returns internal server error', async () => {
         client.get.mockRejectedValue(new Error('Network error'));
-        const functionCall = () => gateway.getDocumentSubmission(id);
+        const functionCall = () =>
+          gateway.getDocumentSubmission(Constants.DUMMY_EMAIL, id);
         expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -462,6 +491,7 @@ describe('Evidence api gateway', () => {
 
       it('calls axios correctly', async () => {
         await gateway.getDocumentSubmissionsForResident(
+          Constants.DUMMY_EMAIL,
           serviceRequestedBy,
           residentId
         );
@@ -471,6 +501,7 @@ describe('Evidence api gateway', () => {
             headers: {
               Authorization:
                 process.env.EVIDENCE_API_TOKEN_DOCUMENT_SUBMISSIONS_GET,
+              UserEmail: Constants.DUMMY_EMAIL,
             },
             params: {
               serviceRequestedBy: serviceRequestedBy,
@@ -482,6 +513,7 @@ describe('Evidence api gateway', () => {
 
       it('maps the response', async () => {
         await gateway.getDocumentSubmissionsForResident(
+          Constants.DUMMY_EMAIL,
           serviceRequestedBy,
           residentId
         );
@@ -495,6 +527,7 @@ describe('Evidence api gateway', () => {
 
       it('returns mapped EvidenceTypes', async () => {
         const result = await gateway.getDocumentSubmissionsForResident(
+          Constants.DUMMY_EMAIL,
           serviceRequestedBy,
           residentId
         );
@@ -507,6 +540,7 @@ describe('Evidence api gateway', () => {
         client.get.mockRejectedValue(new Error('Network error'));
         const functionCall = () =>
           gateway.getDocumentSubmissionsForResident(
+            Constants.DUMMY_EMAIL,
             serviceRequestedBy,
             residentId
           );

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -50,6 +50,7 @@ export class EvidenceApiGateway {
   }
 
   async getEvidenceRequests(
+    userEmail: string,
     teamName: string,
     state?: EvidenceRequestState | null
   ): Promise<EvidenceRequest[]> {
@@ -57,7 +58,10 @@ export class EvidenceApiGateway {
       const { data } = await this.client.get<EvidenceRequestResponse[]>(
         '/api/v1/evidence_requests',
         {
-          headers: { Authorization: tokens?.evidence_requests?.GET },
+          headers: {
+            Authorization: tokens?.evidence_requests?.GET,
+            UserEmail: userEmail,
+          },
           params: { serviceRequestedBy: teamName, state: state },
         }
       );
@@ -69,12 +73,18 @@ export class EvidenceApiGateway {
     }
   }
 
-  async getDocumentTypes(teamName: string): Promise<DocumentType[]> {
+  async getDocumentTypes(
+    userEmail: string,
+    teamName: string
+  ): Promise<DocumentType[]> {
     try {
       const { data } = await this.client.get<IDocumentType[]>(
         `/api/v1/document_types/${teamName}`,
         {
-          headers: { Authorization: tokens?.document_types?.GET },
+          headers: {
+            Authorization: tokens?.document_types?.GET,
+            UserEmail: userEmail,
+          },
         }
       );
       return data.map(ResponseMapper.mapDocumentType);
@@ -85,13 +95,17 @@ export class EvidenceApiGateway {
   }
 
   async getStaffSelectedDocumentTypes(
+    userEmail: string,
     teamName: string
   ): Promise<DocumentType[]> {
     try {
       const { data } = await this.client.get<IDocumentType[]>(
         `/api/v1/document_types/staff_selected/${teamName}`,
         {
-          headers: { Authorization: tokens?.document_types?.GET },
+          headers: {
+            Authorization: tokens?.document_types?.GET,
+            UserEmail: userEmail,
+          },
         }
       );
       return data.map(ResponseMapper.mapDocumentType);
@@ -101,11 +115,19 @@ export class EvidenceApiGateway {
     }
   }
 
-  async getEvidenceRequest(id: string): Promise<EvidenceRequest> {
+  async getEvidenceRequest(
+    userEmail: string,
+    id: string
+  ): Promise<EvidenceRequest> {
     try {
       const { data } = await this.client.get<EvidenceRequestResponse>(
         `/api/v1/evidence_requests/${id}`,
-        { headers: { Authorization: tokens?.evidence_requests?.GET } }
+        {
+          headers: {
+            Authorization: tokens?.evidence_requests?.GET,
+            UserEmail: userEmail,
+          },
+        }
       );
       return ResponseMapper.mapEvidenceRequest(data);
     } catch (err) {
@@ -115,6 +137,7 @@ export class EvidenceApiGateway {
   }
 
   async updateDocumentSubmission(
+    userEmail: string,
     documentSubmissionId: string,
     params: Partial<IDocumentSubmission>
   ): Promise<DocumentSubmission> {
@@ -122,7 +145,12 @@ export class EvidenceApiGateway {
       const { data } = await this.client.patch<DocumentSubmissionResponse>(
         `/api/v1/document_submissions/${documentSubmissionId}`,
         params,
-        { headers: { Authorization: tokens?.document_submissions?.PATCH } }
+        {
+          headers: {
+            Authorization: tokens?.document_submissions?.PATCH,
+            UserEmail: userEmail,
+          },
+        }
       );
       return ResponseMapper.mapDocumentSubmission(data);
     } catch (err) {
@@ -131,11 +159,19 @@ export class EvidenceApiGateway {
     }
   }
 
-  async getDocumentSubmission(id: string): Promise<DocumentSubmission> {
+  async getDocumentSubmission(
+    userEmail: string,
+    id: string
+  ): Promise<DocumentSubmission> {
     try {
       const { data } = await this.client.get<DocumentSubmissionResponse>(
         `/api/v1/document_submissions/${id}`,
-        { headers: { Authorization: tokens?.document_submissions?.GET } }
+        {
+          headers: {
+            Authorization: tokens?.document_submissions?.GET,
+            UserEmail: userEmail,
+          },
+        }
       );
       return ResponseMapper.mapDocumentSubmission(data);
     } catch (err) {
@@ -145,6 +181,7 @@ export class EvidenceApiGateway {
   }
 
   async getDocumentSubmissionsForResident(
+    userEmail: string,
     serviceRequestedBy: string,
     residentId: string
   ): Promise<DocumentSubmission[]> {
@@ -152,7 +189,10 @@ export class EvidenceApiGateway {
       const { data } = await this.client.get<DocumentSubmissionResponse[]>(
         '/api/v1/document_submissions',
         {
-          headers: { Authorization: tokens?.document_submissions?.GET },
+          headers: {
+            Authorization: tokens?.document_submissions?.GET,
+            UserEmail: userEmail,
+          },
           params: {
             serviceRequestedBy: serviceRequestedBy,
             residentId: residentId,
@@ -166,12 +206,12 @@ export class EvidenceApiGateway {
     }
   }
 
-  async getResident(residentId: string): Promise<Resident> {
+  async getResident(userEmail: string, residentId: string): Promise<Resident> {
     try {
       const { data } = await this.client.get<ResidentResponse>(
         `/api/v1/residents/${residentId}`,
         {
-          headers: { Authorization: tokens?.residents?.GET },
+          headers: { Authorization: tokens?.residents?.GET, UserEmail: 'test' },
           params: {
             residentId: residentId,
           },

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -211,7 +211,10 @@ export class EvidenceApiGateway {
       const { data } = await this.client.get<ResidentResponse>(
         `/api/v1/residents/${residentId}`,
         {
-          headers: { Authorization: tokens?.residents?.GET, UserEmail: 'test' },
+          headers: {
+            Authorization: tokens?.residents?.GET,
+            UserEmail: userEmail,
+          },
           params: {
             residentId: residentId,
           },
@@ -227,10 +230,15 @@ export class EvidenceApiGateway {
   async request(
     pathSegments: string[],
     method: Method,
+    headers: unknown,
     body?: unknown,
     params?: unknown
   ): Promise<{ data?: string; status: number }> {
     const token = this.getToken(pathSegments, method);
+    const headerDictionary: TokenDictionary = JSON.parse(
+      JSON.stringify(headers)
+    );
+    const userEmail = headerDictionary['useremail'];
 
     try {
       const { status, data } = await this.client.request({
@@ -240,6 +248,7 @@ export class EvidenceApiGateway {
         params: params,
         headers: {
           Authorization: token,
+          UserEmail: userEmail,
         },
         validateStatus() {
           return true;

--- a/src/gateways/internal-api.test.ts
+++ b/src/gateways/internal-api.test.ts
@@ -57,10 +57,8 @@ describe('Internal API Gateway', () => {
 
         expect(client.patch).toHaveBeenCalledWith(
           `/api/evidence/document_submissions/${documentSubmissionId}`,
-          {
-            headers: { UserEmail: Constants.DUMMY_EMAIL },
-            params: { state: 'UPLOADED' },
-          }
+          { params: { state: 'UPLOADED' } },
+          { headers: { UserEmail: Constants.DUMMY_EMAIL } }
         );
       });
 

--- a/src/gateways/internal-api.test.ts
+++ b/src/gateways/internal-api.test.ts
@@ -12,6 +12,7 @@ import {
 } from './internal-api';
 import { Resident } from '../domain/resident';
 import { EvidenceRequest } from '../domain/evidence-request';
+import { Constants } from '../helpers/Constants';
 
 jest.mock('../boundary/response-mapper');
 const mockedResponseMapper = ResponseMapper as jest.Mocked<
@@ -46,20 +47,26 @@ describe('Internal API Gateway', () => {
       });
 
       it('makes the api request', async () => {
-        await gateway.updateDocumentSubmission(documentSubmissionId, {
-          state: DocumentState.UPLOADED,
-        });
+        await gateway.updateDocumentSubmission(
+          Constants.DUMMY_EMAIL,
+          documentSubmissionId,
+          {
+            state: DocumentState.UPLOADED,
+          }
+        );
 
-        expect(
-          client.patch
-        ).toHaveBeenCalledWith(
+        expect(client.patch).toHaveBeenCalledWith(
           `/api/evidence/document_submissions/${documentSubmissionId}`,
-          { state: 'UPLOADED' }
+          {
+            headers: { UserEmail: Constants.DUMMY_EMAIL },
+            params: { state: 'UPLOADED' },
+          }
         );
       });
 
       it('returns the updated model', async () => {
         const result = await gateway.updateDocumentSubmission(
+          Constants.DUMMY_EMAIL,
           documentSubmissionId,
           {
             state: DocumentState.UPLOADED,
@@ -74,9 +81,13 @@ describe('Internal API Gateway', () => {
       it('returns internal server error', async () => {
         client.patch.mockRejectedValue(new Error('Internal server error'));
         const functionCall = () =>
-          gateway.updateDocumentSubmission(documentSubmissionId, {
-            state: DocumentState.UPLOADED,
-          });
+          gateway.updateDocumentSubmission(
+            Constants.DUMMY_EMAIL,
+            documentSubmissionId,
+            {
+              state: DocumentState.UPLOADED,
+            }
+          );
         await expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -102,18 +113,22 @@ describe('Internal API Gateway', () => {
       });
 
       it('makes the api request', async () => {
-        await gateway.createDocumentSubmission(evidenceRequestId, documentType);
+        await gateway.createDocumentSubmission(
+          Constants.DUMMY_EMAIL,
+          evidenceRequestId,
+          documentType
+        );
 
-        expect(
-          client.post
-        ).toHaveBeenCalledWith(
+        expect(client.post).toHaveBeenCalledWith(
           `/api/evidence/evidence_requests/${evidenceRequestId}/document_submissions`,
-          { documentType }
+          { documentType },
+          { headers: { UserEmail: Constants.DUMMY_EMAIL } }
         );
       });
 
       it('returns the updated model', async () => {
         const result = await gateway.createDocumentSubmission(
+          Constants.DUMMY_EMAIL,
           evidenceRequestId,
           documentType
         );
@@ -126,7 +141,11 @@ describe('Internal API Gateway', () => {
       it('returns internal server error', async () => {
         client.post.mockRejectedValue(new Error('Internal server error'));
         const functionCall = () =>
-          gateway.createDocumentSubmission(evidenceRequestId, documentType);
+          gateway.createDocumentSubmission(
+            Constants.DUMMY_EMAIL,
+            evidenceRequestId,
+            documentType
+          );
         await expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -159,16 +178,22 @@ describe('Internal API Gateway', () => {
       });
 
       it('makes the api request', async () => {
-        await gateway.createEvidenceRequest(baseRequest);
+        await gateway.createEvidenceRequest(Constants.DUMMY_EMAIL, baseRequest);
 
         expect(client.post).toHaveBeenCalledWith(
           `/api/evidence/evidence_requests`,
-          baseRequest
+          baseRequest,
+          {
+            headers: { UserEmail: Constants.DUMMY_EMAIL },
+          }
         );
       });
 
       it('returns the updated model', async () => {
-        const result = await gateway.createEvidenceRequest(baseRequest);
+        const result = await gateway.createEvidenceRequest(
+          Constants.DUMMY_EMAIL,
+          baseRequest
+        );
 
         expect(result).toBe(expectedResult);
       });
@@ -177,7 +202,8 @@ describe('Internal API Gateway', () => {
     describe('when there is an error', () => {
       it('returns internal server error', async () => {
         client.post.mockRejectedValue(new Error('Internal server error'));
-        const functionCall = () => gateway.createEvidenceRequest(baseRequest);
+        const functionCall = () =>
+          gateway.createEvidenceRequest(Constants.DUMMY_EMAIL, baseRequest);
         await expect(functionCall).rejects.toEqual(
           new InternalServerError('Internal server error')
         );
@@ -202,7 +228,7 @@ describe('Internal API Gateway', () => {
       });
 
       it('makes the api request', async () => {
-        await gateway.searchResidents({
+        await gateway.searchResidents(Constants.DUMMY_EMAIL, {
           serviceRequestedBy: searchQuery,
           searchQuery: searchQuery,
         });
@@ -214,12 +240,13 @@ describe('Internal API Gateway', () => {
               serviceRequestedBy: searchQuery,
               searchQuery: searchQuery,
             },
+            headers: { UserEmail: Constants.DUMMY_EMAIL },
           }
         );
       });
 
       it('returns the updated model', async () => {
-        const result = await gateway.searchResidents({
+        const result = await gateway.searchResidents(Constants.DUMMY_EMAIL, {
           serviceRequestedBy: searchQuery,
           searchQuery: searchQuery,
         });
@@ -232,7 +259,7 @@ describe('Internal API Gateway', () => {
       it('returns internal server error', async () => {
         client.get.mockRejectedValue(new Error('Internal server error'));
         const functionCall = () =>
-          gateway.searchResidents({
+          gateway.searchResidents(Constants.DUMMY_EMAIL, {
             serviceRequestedBy: searchQuery,
             searchQuery: searchQuery,
           });

--- a/src/gateways/internal-api.test.ts
+++ b/src/gateways/internal-api.test.ts
@@ -57,7 +57,7 @@ describe('Internal API Gateway', () => {
 
         expect(client.patch).toHaveBeenCalledWith(
           `/api/evidence/document_submissions/${documentSubmissionId}`,
-          { params: { state: 'UPLOADED' } },
+          { state: 'UPLOADED' },
           { headers: { UserEmail: Constants.DUMMY_EMAIL } }
         );
       });

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -74,12 +74,18 @@ export class InternalApiGateway {
   }
 
   async createEvidenceRequest(
+    userEmail: string,
     payload: EvidenceRequestRequest
   ): Promise<EvidenceRequest> {
     try {
       const { data } = await this.client.post<EvidenceRequestResponse>(
         '/api/evidence/evidence_requests',
-        payload
+        payload,
+        {
+          headers: {
+            UserEmail: userEmail,
+          },
+        }
       );
 
       return ResponseMapper.mapEvidenceRequest(data);
@@ -90,13 +96,19 @@ export class InternalApiGateway {
   }
 
   async createDocumentSubmission(
+    userEmail: string,
     evidenceRequestId: string,
     documentType: string
   ): Promise<DocumentSubmission> {
     try {
       const { data } = await this.client.post<DocumentSubmissionResponse>(
         `/api/evidence/evidence_requests/${evidenceRequestId}/document_submissions`,
-        { documentType }
+        { documentType },
+        {
+          headers: {
+            UserEmail: userEmail,
+          },
+        }
       );
       return ResponseMapper.mapDocumentSubmission(data);
     } catch (err) {
@@ -106,13 +118,21 @@ export class InternalApiGateway {
   }
 
   async updateDocumentSubmission(
+    userEmail: string,
     documentSubmissionId: string,
     params: DocumentSubmissionRequest
   ): Promise<DocumentSubmission> {
     try {
       const { data } = await this.client.patch<DocumentSubmissionResponse>(
         `/api/evidence/document_submissions/${documentSubmissionId}`,
-        params
+        {
+          params: params,
+        },
+        {
+          headers: {
+            UserEmail: userEmail,
+          },
+        }
       );
       return ResponseMapper.mapDocumentSubmission(data);
     } catch (err) {
@@ -121,12 +141,18 @@ export class InternalApiGateway {
     }
   }
 
-  async searchResidents(params: ResidentRequest): Promise<Resident[]> {
+  async searchResidents(
+    userEmail: string,
+    params: ResidentRequest
+  ): Promise<Resident[]> {
     try {
       const { data } = await this.client.get<ResidentResponse[]>(
         `/api/evidence/residents/search`,
         {
           params: params,
+          headers: {
+            UserEmail: userEmail,
+          },
         }
       );
       return ResponseMapper.mapResidentResponseList(data);

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -125,9 +125,7 @@ export class InternalApiGateway {
     try {
       const { data } = await this.client.patch<DocumentSubmissionResponse>(
         `/api/evidence/document_submissions/${documentSubmissionId}`,
-        {
-          params: params,
-        },
+        params,
         {
           headers: {
             UserEmail: userEmail,

--- a/src/helpers/Constants.ts
+++ b/src/helpers/Constants.ts
@@ -1,0 +1,3 @@
+export abstract class Constants {
+  static readonly DUMMY_EMAIL: string = 'resident-dummy-value';
+}

--- a/src/pages/api/evidence/[...path].ts
+++ b/src/pages/api/evidence/[...path].ts
@@ -25,6 +25,7 @@ const endpoint: NextApiHandler = async (req, res) => {
     const { status, data } = await evidenceApiGateway.request(
       path,
       req.method as Method,
+      req.headers,
       req.body,
       req.query
     );

--- a/src/pages/resident/[requestId]/confirmation.tsx
+++ b/src/pages/resident/[requestId]/confirmation.tsx
@@ -6,6 +6,7 @@ import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import { withAuth } from 'src/helpers/authed-server-side-props';
 import { TeamHelper } from '../../../services/team-helper';
 import { Team } from 'src/domain/team';
+import { Constants } from '../../../helpers/Constants';
 
 type ConfirmationProps = {
   residentReferenceId: string;
@@ -58,6 +59,7 @@ export const getServerSideProps = withAuth(async (ctx) => {
   };
   const evidenceApiGateway = new EvidenceApiGateway();
   const evidenceRequest = await evidenceApiGateway.getEvidenceRequest(
+    Constants.DUMMY_EMAIL,
     requestId
   );
   const residentReferenceId = evidenceRequest.resident.referenceId;

--- a/src/pages/resident/[requestId]/index.tsx
+++ b/src/pages/resident/[requestId]/index.tsx
@@ -7,6 +7,7 @@ import { EvidenceApiGateway } from '../../../gateways/evidence-api';
 import { TeamHelper } from '../../../services/team-helper';
 import { Team } from '../../../domain/team';
 import { NextPage } from 'next';
+import { Constants } from '../../../helpers/Constants';
 
 type IndexProps = {
   requestId: string;
@@ -48,6 +49,7 @@ export const getServerSideProps = withAuth(async (ctx) => {
   };
   const evidenceApiGateway = new EvidenceApiGateway();
   const evidenceRequest = await evidenceApiGateway.getEvidenceRequest(
+    Constants.DUMMY_EMAIL,
     requestId
   );
 

--- a/src/pages/resident/[requestId]/upload.tsx
+++ b/src/pages/resident/[requestId]/upload.tsx
@@ -6,6 +6,7 @@ import { DocumentType } from '../../../domain/document-type';
 import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import Layout from '../../../components/ResidentLayout';
 import UploaderForm from '../../../components/UploaderForm';
+import { Constants } from '../../../helpers/Constants';
 
 type UploadProps = {
   requestId: string;
@@ -57,7 +58,10 @@ export const getServerSideProps: GetServerSideProps<
   if (!requestId) return { notFound: true };
 
   const gateway = new EvidenceApiGateway();
-  const evidenceRequest = await gateway.getEvidenceRequest(requestId);
+  const evidenceRequest = await gateway.getEvidenceRequest(
+    Constants.DUMMY_EMAIL,
+    requestId
+  );
   const evidenceRequestId = evidenceRequest.id;
   const documentTypes = evidenceRequest.documentTypes;
   const feedbackUrl = process.env.FEEDBACK_FORM_RESIDENT_URL as string;

--- a/src/pages/teams/[teamId]/dashboard/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/index.tsx
@@ -15,15 +15,18 @@ import TableSkeleton from '../../../../components/TableSkeleton';
 import { RequestAuthorizer } from '../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../services/team-helper';
 import { Team } from '../../../../domain/team';
+import { User } from '../../../../domain/user';
 
 type BrowseResidentsProps = {
   evidenceRequests: EvidenceRequest[];
   team: Team;
+  user: User;
 };
 
 const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
   evidenceRequests,
   team,
+  user,
 }) => {
   // see here https://www.carlrippon.com/typed-usestate-with-typescript/ to explain useState<Resident[]>()
   const [results, setResults] = useState<Resident[]>();
@@ -35,7 +38,7 @@ const BrowseResidents: NextPage<WithUser<BrowseResidentsProps>> = ({
       setFormSearchQuery(searchQuery);
       setLoading(true);
       const gateway = new InternalApiGateway();
-      const data = await gateway.searchResidents({
+      const data = await gateway.searchResidents(user.email, {
         serviceRequestedBy: team.name,
         searchQuery: searchQuery,
       });
@@ -110,7 +113,7 @@ export const getServerSideProps = withAuth<BrowseResidentsProps>(
       team.name
     );
     return {
-      props: { evidenceRequests, team },
+      props: { evidenceRequests, team, user },
     };
   }
 );

--- a/src/pages/teams/[teamId]/dashboard/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/index.tsx
@@ -95,7 +95,7 @@ export const getServerSideProps = withAuth<BrowseResidentsProps>(
     );
 
     const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
-    if (!userAuthorizedToViewTeam || team === undefined) {
+    if (!userAuthorizedToViewTeam || team === undefined || user === undefined) {
       return {
         redirect: {
           destination: '/teams',
@@ -105,7 +105,10 @@ export const getServerSideProps = withAuth<BrowseResidentsProps>(
     }
 
     const gateway = new EvidenceApiGateway();
-    const evidenceRequests = await gateway.getEvidenceRequests(team.name);
+    const evidenceRequests = await gateway.getEvidenceRequests(
+      user.email,
+      team.name
+    );
     return {
       props: { evidenceRequests, team },
     };

--- a/src/pages/teams/[teamId]/dashboard/requests/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/index.tsx
@@ -47,7 +47,7 @@ export const getServerSideProps = withAuth<RequestsIndexPageProps>(
     );
 
     const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
-    if (!userAuthorizedToViewTeam || team === undefined) {
+    if (!userAuthorizedToViewTeam || team === undefined || user === undefined) {
       return {
         redirect: {
           destination: '/teams',
@@ -58,6 +58,7 @@ export const getServerSideProps = withAuth<RequestsIndexPageProps>(
 
     const gateway = new EvidenceApiGateway();
     const evidenceRequests = await gateway.getEvidenceRequests(
+      user.email,
       team.name,
       EvidenceRequestState.PENDING
     );

--- a/src/pages/teams/[teamId]/dashboard/requests/new.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/new.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps = withAuth<RequestsNewPageProps>(
     );
 
     const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
-    if (!userAuthorizedToViewTeam || team === undefined) {
+    if (!userAuthorizedToViewTeam || team === undefined || user === undefined) {
       return {
         redirect: {
           destination: '/teams',
@@ -79,7 +79,7 @@ export const getServerSideProps = withAuth<RequestsNewPageProps>(
     }
 
     const gateway = new EvidenceApiGateway();
-    const documentTypes = await gateway.getDocumentTypes(team.name);
+    const documentTypes = await gateway.getDocumentTypes(user.email, team.name);
     return { props: { documentTypes, team } };
   }
 );

--- a/src/pages/teams/[teamId]/dashboard/requests/new.tsx
+++ b/src/pages/teams/[teamId]/dashboard/requests/new.tsx
@@ -13,10 +13,12 @@ import {
 import { RequestAuthorizer } from '../../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../../services/team-helper';
 import { Team } from '../../../../../domain/team';
+import { User } from '../../../../../domain/user';
 
 type RequestsNewPageProps = {
   documentTypes: DocumentType[];
   team: Team;
+  user: User;
 };
 
 const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
@@ -30,9 +32,9 @@ const RequestsNewPage: NextPage<WithUser<RequestsNewPageProps>> = ({
     const gateway = new InternalApiGateway();
     const payload: EvidenceRequestRequest = {
       ...values,
-      userRequestedBy: user?.email,
+      userRequestedBy: user.email,
     };
-    await gateway.createEvidenceRequest(payload);
+    await gateway.createEvidenceRequest(user.email, payload);
     setComplete(true);
   }, []);
 
@@ -80,7 +82,7 @@ export const getServerSideProps = withAuth<RequestsNewPageProps>(
 
     const gateway = new EvidenceApiGateway();
     const documentTypes = await gateway.getDocumentTypes(user.email, team.name);
-    return { props: { documentTypes, team } };
+    return { props: { documentTypes, team, user } };
   }
 );
 

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -263,7 +263,7 @@ export const getServerSideProps = withAuth(async (ctx) => {
   );
 
   const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
-  if (!userAuthorizedToViewTeam || team === undefined) {
+  if (!userAuthorizedToViewTeam || team === undefined || user === undefined) {
     return {
       redirect: {
         destination: '/teams',
@@ -272,12 +272,14 @@ export const getServerSideProps = withAuth(async (ctx) => {
     };
   }
   const documentSubmission = await evidenceApiGateway.getDocumentSubmission(
+    user.email,
     documentSubmissionId
   );
   const staffSelectedDocumentTypes = await evidenceApiGateway.getStaffSelectedDocumentTypes(
+    user.email,
     team.name
   );
-  const resident = await evidenceApiGateway.getResident(residentId);
+  const resident = await evidenceApiGateway.getResident(user.email, residentId);
 
   let downloadUrl = '';
   if (documentSubmission && documentSubmission.document) {

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -23,6 +23,7 @@ import styles from 'src/styles/Document.module.scss';
 import { RequestAuthorizer } from '../../../../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../../../../services/team-helper';
 import { DocumentType } from '../../../../../../../domain/document-type';
+import { User } from '../../../../../../../domain/user';
 
 const gateway = new InternalApiGateway();
 
@@ -34,6 +35,7 @@ type DocumentDetailPageQuery = {
 
 type DocumentDetailPageProps = {
   teamId: string;
+  user: User;
   resident: Resident;
   documentSubmission: DocumentSubmission;
   staffSelectedDocumentTypes: DocumentType[];
@@ -42,6 +44,7 @@ type DocumentDetailPageProps = {
 
 const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   teamId,
+  user,
   resident,
   documentSubmission: _documentSubmission,
   staffSelectedDocumentTypes,
@@ -63,6 +66,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       try {
         const payload = buildAcceptDocumentSubmissionRequest(values);
         const updated = await gateway.updateDocumentSubmission(
+          user.email,
           documentSubmissionId,
           payload
         );
@@ -101,6 +105,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
     async (values: DocumentSubmissionForm) => {
       try {
         const updated = await gateway.updateDocumentSubmission(
+          user.email,
           documentSubmissionId,
           {
             state: values.state,
@@ -291,6 +296,7 @@ export const getServerSideProps = withAuth(async (ctx) => {
   return {
     props: {
       teamId,
+      user,
       resident,
       documentSubmission,
       staffSelectedDocumentTypes,

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
@@ -151,7 +151,7 @@ export const getServerSideProps = withAuth<ResidentPageProps>(async (ctx) => {
   );
 
   const team = TeamHelper.getTeamFromId(TeamHelper.getTeamsJson(), teamId);
-  if (!userAuthorizedToViewTeam || team === undefined) {
+  if (!userAuthorizedToViewTeam || team === undefined || user === undefined) {
     return {
       redirect: {
         destination: '/teams',
@@ -162,10 +162,11 @@ export const getServerSideProps = withAuth<ResidentPageProps>(async (ctx) => {
 
   const gateway = new EvidenceApiGateway();
   const documentSubmissions = await gateway.getDocumentSubmissionsForResident(
+    user.email,
     team.name,
     residentId
   );
-  const resident = await gateway.getResident(residentId);
+  const resident = await gateway.getResident(user.email, residentId);
   return {
     props: { documentSubmissions, resident, teamId },
   };

--- a/src/services/upload-form-model.test.ts
+++ b/src/services/upload-form-model.test.ts
@@ -3,6 +3,7 @@ import * as S3Gateway from '../gateways/s3-gateway';
 import * as MockS3Gateway from '../gateways/__mocks__/s3-gateway';
 import documentSubmissionFixture from '../../cypress/fixtures/document_submissions/index.json';
 import { ResponseMapper } from '../boundary/response-mapper';
+import { Constants } from '../helpers/Constants';
 
 const { uploadMock } = S3Gateway as typeof MockS3Gateway;
 const evidenceRequestId = '123';
@@ -58,16 +59,19 @@ describe('UploadFormModel', () => {
 
       expect(mockCreateDocumentSubmission).toHaveBeenNthCalledWith(
         1,
+        Constants.DUMMY_EMAIL,
         evidenceRequestId,
         documentTypes[0].id
       );
       expect(mockCreateDocumentSubmission).toHaveBeenNthCalledWith(
         2,
+        Constants.DUMMY_EMAIL,
         evidenceRequestId,
         documentTypes[1].id
       );
       expect(mockCreateDocumentSubmission).toHaveBeenNthCalledWith(
         2,
+        Constants.DUMMY_EMAIL,
         evidenceRequestId,
         documentTypes[1].id
       );
@@ -98,16 +102,19 @@ describe('UploadFormModel', () => {
 
       expect(mockUpdateState).toHaveBeenNthCalledWith(
         1,
+        Constants.DUMMY_EMAIL,
         documentSubmission.id,
         { state: 'UPLOADED' }
       );
       expect(mockUpdateState).toHaveBeenNthCalledWith(
         2,
+        Constants.DUMMY_EMAIL,
         documentSubmission.id,
         { state: 'UPLOADED' }
       );
       expect(mockUpdateState).toHaveBeenNthCalledWith(
         3,
+        Constants.DUMMY_EMAIL,
         documentSubmission.id,
         { state: 'UPLOADED' }
       );

--- a/src/services/upload-form-model.ts
+++ b/src/services/upload-form-model.ts
@@ -6,6 +6,7 @@ import { S3Gateway } from '../gateways/s3-gateway';
 import * as Yup from 'yup';
 import { InternalApiGateway } from '../gateways/internal-api';
 import { DocumentType } from '../domain/document-type';
+import { Constants } from '../helpers/Constants';
 
 export type FormValues = {
   [documentTypeId: string]: File[];
@@ -80,6 +81,7 @@ export class UploadFormModel {
     for (const [documentTypeId, files] of Object.entries(formValues)) {
       for (const file of files) {
         const documentSubmission = await this.gateway.createDocumentSubmission(
+          Constants.DUMMY_EMAIL,
           evidenceRequestId,
           documentTypeId
         );
@@ -98,8 +100,12 @@ export class UploadFormModel {
   }
 
   private async updateDocumentState(documentSubmissionId: string) {
-    await this.gateway.updateDocumentSubmission(documentSubmissionId, {
-      state: DocumentState.UPLOADED,
-    });
+    await this.gateway.updateDocumentSubmission(
+      Constants.DUMMY_EMAIL,
+      documentSubmissionId,
+      {
+        state: DocumentState.UPLOADED,
+      }
+    );
   }
 }


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-276

 * `EvidenceApiGateway`
   *  Decided to pass `userEmail` as the first parameter in functions because some functions have optional arguments which meant `userEmail` couldn't always be passed as the final param. I thought it was better to have consistency so pass it as the first param
 * `InternalApiGateway`
   * Retrieve `req. headers` from the Axios request in `[...path]` and pass them on to `EvidenceApiGateway.request`. This extracts `useremail` from the headers provided and attaches it along with `Authorization` when sending requests to the evidence-api