### PR TITLE
DES-253: provide palo altos SSL certificate to axios

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -41,6 +41,7 @@ functions:
       APP_URL: https://${self:custom.alias}
       HACKNEY_COOKIE_NAME: hackneyToken
       NODE_ENV: ${self:provider.stage}
+      PALO_ALTOS_SSL_CERTIFICATE: ${ssm:palo-alto-ssl-certificate}
       EVIDENCE_API_BASE_URL: ${ssm:/evidence-api/${self:provider.stage}/base-url}
       EVIDENCE_API_TOKEN_DOCUMENT_TYPES_GET: ${ssm:/evidence-api/${self:provider.stage}/get/document_types/token}
       EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_GET: ${ssm:/evidence-api/${self:provider.stage}/get/evidence_requests/token}

--- a/src/gateways/documents-api.ts
+++ b/src/gateways/documents-api.ts
@@ -1,6 +1,7 @@
 import Axios, { AxiosInstance } from 'axios';
 import { TokenDictionary } from '../../types/api';
 import { InternalServerError } from './internal-api';
+import https from 'https';
 
 const tokens: TokenDictionary = {
   claims: {
@@ -14,7 +15,12 @@ type DocumentsApiGatewayDependencies = {
 };
 
 const defaultDependencies: DocumentsApiGatewayDependencies = {
-  client: Axios.create({ baseURL: process.env.DOCUMENTS_API_BASE_URL }),
+  client: Axios.create({
+    baseURL: process.env.DOCUMENTS_API_BASE_URL,
+    httpsAgent: new https.Agent({
+      cert: process.env.PALO_ALTOS_SSL_CERTIFICATE,
+    }),
+  }),
 };
 
 export class DocumentsApiGateway {

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -16,6 +16,7 @@ import { EvidenceRequest } from 'src/domain/evidence-request';
 import { DocumentType } from 'src/domain/document-type';
 import { EvidenceRequestState } from 'src/domain/enums/EvidenceRequestState';
 import { Resident } from 'src/domain/resident';
+import https from 'https';
 
 const tokens: TokenDictionary = {
   document_types: {
@@ -39,7 +40,12 @@ type EvidenceApiGatewayDependencies = {
 };
 
 const defaultDependencies: EvidenceApiGatewayDependencies = {
-  client: Axios.create({ baseURL: process.env.EVIDENCE_API_BASE_URL }),
+  client: Axios.create({
+    baseURL: process.env.EVIDENCE_API_BASE_URL,
+    httpsAgent: new https.Agent({
+      cert: process.env.PALO_ALTOS_SSL_CERTIFICATE,
+    }),
+  }),
 };
 
 export class EvidenceApiGateway {

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -8,6 +8,7 @@ import {
   ResidentResponse,
 } from 'types/api';
 import { ResponseMapper } from '../boundary/response-mapper';
+import https from 'https';
 
 export class InternalServerError extends Error {
   constructor(message: string) {
@@ -68,7 +69,13 @@ export class InternalApiGateway {
   private client: AxiosInstance;
 
   constructor(
-    { client }: InternalApiDependencies = { client: Axios.create() }
+    { client }: InternalApiDependencies = {
+      client: Axios.create({
+        httpsAgent: new https.Agent({
+          cert: process.env.PALO_ALTOS_SSL_CERTIFICATE,
+        }),
+      }),
+    }
   ) {
     this.client = client;
   }


### PR DESCRIPTION
We saw the following error in the `document-evidence-frontend` log:
```
ERROR	Error: self signed certificate in certificate chain
    at TLSSocket.onConnectSecure (_tls_wrap.js:1502:34)
    at TLSSocket.emit (events.js:314:20)
    at TLSSocket._finishInit (_tls_wrap.js:937:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:711:12) {
  code: 'SELF_SIGNED_CERT_IN_CHAIN',
```
To (hopefully) fix it we followed [this guide](https://stackoverflow.com/questions/51363855/how-to-configure-axios-to-use-ssl-certificate) to add additional configuration to Axious