### PR TITLE
DES-253: create PALO_ALTOS_SSL_CERTIFICATE env variable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 module.exports = {
   distDir: 'build/_next',
   target: 'server',
@@ -9,6 +11,13 @@ module.exports = {
         fs: 'empty',
       };
     }
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        'process.env.PALO_ALTOS_SSL_CERTIFICATE': fs.readFileSync(
+          '/opt/palo-alto-ssl-certificate.crt'
+        ),
+      })
+    );
 
     return config;
   },

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+const fs = require('fs');
 
 module.exports = {
   distDir: 'build/_next',
@@ -11,13 +11,18 @@ module.exports = {
         fs: 'empty',
       };
     }
-    config.plugins.push(
-      new webpack.DefinePlugin({
-        'process.env.PALO_ALTOS_SSL_CERTIFICATE': fs.readFileSync(
-          '/opt/palo-alto-ssl-certificate.crt'
-        ),
-      })
-    );
+    // Configures environment variable for Palo Altos SSL certificate
+    // This should only be set when running the app in staging or production
+    let app_env = process.env.APP_ENV;
+    if (app_env === 'staging' || app_env === 'production') {
+      config.plugins.push(
+        new webpack.DefinePlugin({
+          'process.env.PALO_ALTOS_SSL_CERTIFICATE': fs.readFileSync(
+            '/opt/palo-alto-ssl-certificate.crt'
+          ),
+        })
+      );
+    }
 
     return config;
   },

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -50,7 +50,7 @@ export class EvidenceApiGateway {
 
   constructor({ client } = defaultDependencies) {
     const app_env = process.env.APP_ENV;
-    if (app_env == 'staging' || app_env == 'production') {
+    if (app_env === 'staging' || app_env === 'production') {
       this.client = Axios.create({
         baseURL: process.env.EVIDENCE_API_BASE_URL,
         httpsAgent: new https.Agent({

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -17,7 +17,6 @@ import { DocumentType } from 'src/domain/document-type';
 import { EvidenceRequestState } from 'src/domain/enums/EvidenceRequestState';
 import { Resident } from 'src/domain/resident';
 import https from 'https';
-import * as fs from 'fs';
 
 const tokens: TokenDictionary = {
   document_types: {
@@ -51,13 +50,11 @@ export class EvidenceApiGateway {
 
   constructor({ client } = defaultDependencies) {
     const app_env = process.env.APP_ENV;
-    console.log('app_env', app_env);
-    if (app_env == 'staging') {
-      console.log('adding palo-alto-ssl-certificate.crt');
+    if (app_env == 'staging' || app_env == 'production') {
       this.client = Axios.create({
         baseURL: process.env.EVIDENCE_API_BASE_URL,
         httpsAgent: new https.Agent({
-          ca: fs.readFileSync('/opt/palo-alto-ssl-certificate.crt'),
+          ca: process.env.PALO_ALTOS_SSL_CERTIFICATE,
         }),
       });
     } else {


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-253

- Create `PALO_ALTOS_SSL_CERTIFICATE` env variable instead of reading the certificate from disk every time we instantiate `EvidenceApiGateway`