### PR TITLE
DES-253: revert PALO_ALTOS_SSL_CERTIFICATE env variable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 module.exports = {
   distDir: 'build/_next',
   target: 'server',
@@ -10,18 +8,6 @@ module.exports = {
       config.node = {
         fs: 'empty',
       };
-    }
-    // Configures environment variable for Palo Altos SSL certificate
-    // This should only be set when running the app in staging or production
-    let app_env = process.env.APP_ENV;
-    if (app_env === 'staging' || app_env === 'production') {
-      config.plugins.push(
-        new webpack.DefinePlugin({
-          'process.env.PALO_ALTOS_SSL_CERTIFICATE': fs.readFileSync(
-            '/opt/palo-alto-ssl-certificate.crt'
-          ),
-        })
-      );
     }
 
     return config;

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -53,7 +53,7 @@ export class EvidenceApiGateway {
     const app_env = process.env.APP_ENV;
     if (app_env == 'staging' || app_env == 'production') {
       this.client = Axios.create({
-        baseURL: process.env.DOCUMENTS_API_BASE_URL,
+        baseURL: process.env.EVIDENCE_API_BASE_URL,
         httpsAgent: new https.Agent({
           ca: fs.readFileSync('/opt/palo-alto-ssl-certificate.crt'),
         }),

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -17,6 +17,7 @@ import { DocumentType } from 'src/domain/document-type';
 import { EvidenceRequestState } from 'src/domain/enums/EvidenceRequestState';
 import { Resident } from 'src/domain/resident';
 import https from 'https';
+import fs from 'fs';
 
 const tokens: TokenDictionary = {
   document_types: {
@@ -52,9 +53,9 @@ export class EvidenceApiGateway {
     const app_env = process.env.APP_ENV;
     if (app_env == 'staging' || app_env == 'production') {
       this.client = Axios.create({
-        baseURL: process.env.EVIDENCE_API_BASE_URL,
+        baseURL: process.env.DOCUMENTS_API_BASE_URL,
         httpsAgent: new https.Agent({
-          ca: process.env.PALO_ALTOS_SSL_CERTIFICATE,
+          ca: fs.readFileSync('/opt/palo-alto-ssl-certificate.crt'),
         }),
       });
     } else {


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-253

Still facing the error after #112 and #113:
```
ERROR	Error: self signed certificate in certificate chain
    at TLSSocket.onConnectSecure (_tls_wrap.js:1502:34)
    at TLSSocket.emit (events.js:314:20)
    at TLSSocket._finishInit (_tls_wrap.js:937:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:711:12) {
  code: 'SELF_SIGNED_CERT_IN_CHAIN
```
Think we will need to additional parsing of `fs.readFileSync('/opt/palo-alto-ssl-certificate.crt'` into `PALO_ALTOS_SSL_CERTIFICATE` variable. Reverting this change for now because it feels like we're trying to prematurely optimise, and reading the certificate from disk every time we instantiate `EvidenceApiGateway` may be fine for now