### PR TITLE
Refactor AcceptDialog and RejectDialog to not be on a different link

### DIFF
--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -61,7 +61,7 @@ describe('Can view and manage evidence', () => {
   });
 
   it('lets you see an PDF document detail page with actions and information', () => {
-    cy.get('.toReview a').eq(3).contains('Proof of ID').click();
+    cy.get('.toReview a').eq(1).contains('Proof of ID').click();
 
     cy.contains('h1', 'Namey McNameProof of ID');
 
@@ -77,7 +77,7 @@ describe('Can view and manage evidence', () => {
   });
 
   it('shows an iframe containing the file preview', () => {
-    cy.get('.toReview a').eq(3).contains('Proof of ID').click();
+    cy.get('.toReview a').eq(1).contains('Proof of ID').click();
     cy.get('iframe');
   });
 

--- a/src/components/EvidenceTile.test.tsx
+++ b/src/components/EvidenceTile.test.tsx
@@ -21,8 +21,6 @@ describe('EvidenceTile', () => {
     expect(screen.getByText('1 day ago'));
     expect(screen.getByText('1.0 KB'));
     expect(screen.getByText('PDF'));
-    expect(screen.getByText('Accept'));
-    expect(screen.getByText('Request new file'));
   });
 
   it('renders without actions if document has already been reviewed', async () => {

--- a/src/components/EvidenceTile.tsx
+++ b/src/components/EvidenceTile.tsx
@@ -24,23 +24,6 @@ export const EvidenceTile: FunctionComponent<Props> = (props) => (
         {/* {props.purpose && <> with {props.purpose}</>} */}
       </p>
     </div>
-
-    {props.toReview && (
-      <div className={`lbh-body-s ${styles.actions}`}>
-        <Link
-          href={`/teams/${props.teamId}/dashboard/residents/${props.residentId}/document/${props.id}?action=accept`}
-          scroll={false}
-        >
-          <a className="lbh-link">Accept</a>
-        </Link>
-        <Link
-          href={`/teams/${props.teamId}/dashboard/residents/${props.residentId}/document/${props.id}?action=reject`}
-          scroll={false}
-        >
-          <a className={`lbh-link ${styles.redLink}`}>Request new file</a>
-        </Link>
-      </div>
-    )}
   </li>
 );
 

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -30,7 +30,6 @@ const gateway = new InternalApiGateway();
 type DocumentDetailPageQuery = {
   residentId: string;
   documentSubmissionId: string;
-  action?: string;
 };
 
 type DocumentDetailPageProps = {
@@ -54,7 +53,6 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   const {
     residentId,
     documentSubmissionId,
-    action,
   } = router.query as DocumentDetailPageQuery;
   const [documentSubmission, setDocumentSubmission] = useState(
     _documentSubmission
@@ -127,6 +125,8 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   );
 
   const [submitError, setSubmitError] = useState(false);
+  const [acceptDialogIsOpen, setAcceptDialogIsOpen] = useState(false);
+  const [rejectDialogIsOpen, setRejectDialogIsOpen] = useState(false);
 
   const { document } = documentSubmission;
   if (!document) return null;
@@ -143,6 +143,22 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       console.error('Failed to copy: ', err);
     }
   }
+
+  const handleOpenAcceptDialog = () => {
+    setAcceptDialogIsOpen(true);
+  };
+
+  const handleCloseAcceptDialog = () => {
+    setAcceptDialogIsOpen(false);
+  };
+
+  const handleOpenRejectDialog = () => {
+    setRejectDialogIsOpen(true);
+  };
+
+  const handleCloseRejectDialog = () => {
+    setRejectDialogIsOpen(false);
+  };
 
   function setButtonClicked() {
     setIsClicked(true);
@@ -172,20 +188,18 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
 
       {documentSubmission.state === DocumentState.UPLOADED && (
         <div className={styles.actions}>
-          <Link
-            href={`/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmission.id}?action=accept`}
-            scroll={false}
+          <button
+            className="govuk-button lbh-button"
+            onClick={handleOpenAcceptDialog}
           >
-            <button className="govuk-button lbh-button">Accept</button>
-          </Link>
-          <Link
-            href={`/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmission.id}?action=reject`}
-            scroll={false}
+            Accept
+          </button>
+          <button
+            className="govuk-button govuk-secondary lbh-button lbh-button--secondary"
+            onClick={handleOpenRejectDialog}
           >
-            <button className="govuk-button govuk-secondary lbh-button lbh-button--secondary">
-              Request new file
-            </button>
-          </Link>
+            Request new file
+          </button>
         </div>
       )}
 
@@ -219,25 +233,19 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       {/* <h2 className="lbh-heading-h3">History</h2> */}
       {/* <History /> */}
 
-      <AcceptDialog
-        open={action === 'accept'}
-        staffSelectedDocumentTypes={staffSelectedDocumentTypes}
-        onAccept={handleAccept}
-        onDismiss={() =>
-          router.push(
-            `/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmissionId}`
-          )
-        }
-      />
+      {acceptDialogIsOpen && (
+        <AcceptDialog
+          open={acceptDialogIsOpen}
+          staffSelectedDocumentTypes={staffSelectedDocumentTypes}
+          onAccept={handleAccept}
+          onDismiss={handleCloseAcceptDialog}
+        />
+      )}
 
       <RejectDialog
-        open={action === 'reject'}
+        open={rejectDialogIsOpen}
         onReject={handleReject}
-        onDismiss={() =>
-          router.push(
-            `/teams/${teamId}/dashboard/residents/${residentId}/document/${documentSubmissionId}`
-          )
-        }
+        onDismiss={handleCloseRejectDialog}
       />
     </Layout>
   );

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -125,8 +125,8 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   );
 
   const [submitError, setSubmitError] = useState(false);
-  const [acceptDialogIsOpen, setAcceptDialogIsOpen] = useState(false);
-  const [rejectDialogIsOpen, setRejectDialogIsOpen] = useState(false);
+  const [acceptDialogOpen, setAcceptDialogOpen] = useState(false);
+  const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
 
   const { document } = documentSubmission;
   if (!document) return null;
@@ -145,19 +145,19 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   }
 
   const handleOpenAcceptDialog = () => {
-    setAcceptDialogIsOpen(true);
+    setAcceptDialogOpen(true);
   };
 
   const handleCloseAcceptDialog = () => {
-    setAcceptDialogIsOpen(false);
+    setAcceptDialogOpen(false);
   };
 
   const handleOpenRejectDialog = () => {
-    setRejectDialogIsOpen(true);
+    setRejectDialogOpen(true);
   };
 
   const handleCloseRejectDialog = () => {
-    setRejectDialogIsOpen(false);
+    setRejectDialogOpen(false);
   };
 
   function setButtonClicked() {
@@ -233,9 +233,9 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       {/* <h2 className="lbh-heading-h3">History</h2> */}
       {/* <History /> */}
 
-      {acceptDialogIsOpen && (
+      {acceptDialogOpen && (
         <AcceptDialog
-          open={acceptDialogIsOpen}
+          open={acceptDialogOpen}
           staffSelectedDocumentTypes={staffSelectedDocumentTypes}
           onAccept={handleAccept}
           onDismiss={handleCloseAcceptDialog}
@@ -243,7 +243,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       )}
 
       <RejectDialog
-        open={rejectDialogIsOpen}
+        open={rejectDialogOpen}
         onReject={handleReject}
         onDismiss={handleCloseRejectDialog}
       />


### PR DESCRIPTION
Refactor AcceptDialog and RejectDialog to not be on a different link. Previously, when opening the accept/reject dialog we had `?action=accept` and `?action=reject` attached to the link which meant that anyone could add that to the link of the document details page and get back that dialog box after accepting/rejecting the document which is unwanted behaviour.