### PR TITLE
Add sorting for evidence requests from newest to oldest

### DIFF
--- a/src/components/EvidenceRequestTable.tsx
+++ b/src/components/EvidenceRequestTable.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { EvidenceRequest } from '../domain/evidence-request';
-import { sortEvidenceRequestsDescending } from '../helpers';
-// import Link from 'next/link';
+import { sortEvidenceRequestsDescending } from '../helpers/sorters';
 
 export const EvidenceRequestTable: FunctionComponent<Props> = ({
   requests,

--- a/src/components/EvidenceRequestTable.tsx
+++ b/src/components/EvidenceRequestTable.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useMemo } from 'react';
 import { EvidenceRequest } from '../domain/evidence-request';
+import { sortEvidenceRequestsDescending } from '../helpers';
 // import Link from 'next/link';
 
 export const EvidenceRequestTable: FunctionComponent<Props> = ({
@@ -7,16 +8,14 @@ export const EvidenceRequestTable: FunctionComponent<Props> = ({
 }) => {
   const rows = useMemo(
     () =>
-      requests
-        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-        .map((row) => {
-          return {
-            id: row.id,
-            resident: row.resident.name,
-            document: row.documentTypes[0].title,
-            made: `${row.createdAt.toRelative()}`,
-          };
-        }),
+      sortEvidenceRequestsDescending(requests).map((row) => {
+        return {
+          id: row.id,
+          resident: row.resident.name,
+          document: row.documentTypes[0].title,
+          made: `${row.createdAt.toRelative()}`,
+        };
+      }),
     [requests]
   );
 

--- a/src/components/EvidenceRequestTable.tsx
+++ b/src/components/EvidenceRequestTable.tsx
@@ -7,14 +7,16 @@ export const EvidenceRequestTable: FunctionComponent<Props> = ({
 }) => {
   const rows = useMemo(
     () =>
-      requests.map((row) => {
-        return {
-          id: row.id,
-          resident: row.resident.name,
-          document: row.documentTypes[0].title,
-          made: `${row.createdAt.toRelative()}`,
-        };
-      }),
+      requests
+        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+        .map((row) => {
+          return {
+            id: row.id,
+            resident: row.resident.name,
+            document: row.documentTypes[0].title,
+            made: `${row.createdAt.toRelative()}`,
+          };
+        }),
     [requests]
   );
 

--- a/src/components/ResidentTable.tsx
+++ b/src/components/ResidentTable.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import React, { FunctionComponent, useMemo } from 'react';
 import { EvidenceRequest } from '../domain/evidence-request';
+import { sortEvidenceRequestsDescending } from 'src/helpers/sorters';
 
 export const ResidentTable: FunctionComponent<Props> = ({
   residents,
@@ -8,17 +9,15 @@ export const ResidentTable: FunctionComponent<Props> = ({
 }) => {
   const rows = useMemo(
     () =>
-      residents
-        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-        .map((row) => {
-          return {
-            id: row.resident.id + row.createdAt,
-            residentId: row.resident.id,
-            residentName: row.resident.name,
-            document: row.documentTypes.map((dt) => dt.title).join(', '),
-            uploaded: `${row.createdAt.toRelative()}`,
-          };
-        }),
+      sortEvidenceRequestsDescending(residents).map((row) => {
+        return {
+          id: row.resident.id + row.createdAt,
+          residentId: row.resident.id,
+          residentName: row.resident.name,
+          document: row.documentTypes.map((dt) => dt.title).join(', '),
+          uploaded: `${row.createdAt.toRelative()}`,
+        };
+      }),
     [residents]
   );
 

--- a/src/components/ResidentTable.tsx
+++ b/src/components/ResidentTable.tsx
@@ -8,15 +8,17 @@ export const ResidentTable: FunctionComponent<Props> = ({
 }) => {
   const rows = useMemo(
     () =>
-      residents.map((row) => {
-        return {
-          id: row.resident.id + row.createdAt,
-          residentId: row.resident.id,
-          residentName: row.resident.name,
-          document: row.documentTypes.map((dt) => dt.title).join(', '),
-          uploaded: `${row.createdAt.toRelative()}`,
-        };
-      }),
+      residents
+        .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+        .map((row) => {
+          return {
+            id: row.resident.id + row.createdAt,
+            residentId: row.resident.id,
+            residentName: row.resident.name,
+            document: row.documentTypes.map((dt) => dt.title).join(', '),
+            uploaded: `${row.createdAt.toRelative()}`,
+          };
+        }),
     [residents]
   );
 

--- a/src/helpers/sorters.test.ts
+++ b/src/helpers/sorters.test.ts
@@ -1,0 +1,13 @@
+import { sortEvidenceRequestsDescending } from './sorters';
+import { EvidenceRequest } from '../domain/evidence-request';
+import EvidenceRequestFixture from '../../cypress/fixtures/evidence_requests/index.json';
+
+describe('sortEvidenceRequestsDescending', () => {
+  it('sorts the evidence requests in descending order', () => {
+    const evidenceRequests = (EvidenceRequestFixture as unknown) as EvidenceRequest[];
+    const result = sortEvidenceRequestsDescending(evidenceRequests);
+    expect(result[0].id).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa8');
+    expect(result[1].id).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa7');
+    expect(result[2].id).toBe('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+  });
+});

--- a/src/helpers/sorters.ts
+++ b/src/helpers/sorters.ts
@@ -1,0 +1,7 @@
+import { EvidenceRequest } from '../domain/evidence-request';
+
+export const sortEvidenceRequestsDescending = (
+  evidenceRequests: EvidenceRequest[]
+): EvidenceRequest[] => {
+  return evidenceRequests.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+};


### PR DESCRIPTION
- Sorted evidence requests from newest to oldest on the requests and residents pages