### PR TITLE
Allow only future date when approving a document and comment out headers

### DIFF
--- a/src/components/AcceptDialog.test.tsx
+++ b/src/components/AcceptDialog.test.tsx
@@ -17,7 +17,9 @@ describe('AcceptDialog', () => {
         open={true}
         onDismiss={mockHandler}
         staffSelectedDocumentTypes={staffSelectedDocumentTypes}
-        onAccept={mockHandler}
+        email="email@email"
+        documentSubmissionId="123"
+        redirect="foo"
       />
     );
     // Two radio buttons
@@ -40,7 +42,9 @@ describe('AcceptDialog', () => {
         open={true}
         onDismiss={mockHandler}
         staffSelectedDocumentTypes={staffSelectedDocumentTypes}
-        onAccept={mockHandler}
+        email="email@email"
+        documentSubmissionId="123"
+        redirect="foo"
       />
     );
     fireEvent.click(screen.getByText(yesAcceptButtonText));
@@ -50,13 +54,15 @@ describe('AcceptDialog', () => {
     });
   });
 
-  it('prevents double-submits', async () => {
+  it('checks submit button is disabled', async () => {
     render(
       <AcceptDialog
         open={true}
         onDismiss={mockHandler}
         staffSelectedDocumentTypes={staffSelectedDocumentTypes}
-        onAccept={mockHandler}
+        email="email@email"
+        documentSubmissionId="123"
+        redirect="foo"
       />
     );
 
@@ -68,8 +74,5 @@ describe('AcceptDialog', () => {
     const foundButton = screen.getByText(yesAcceptButtonText).closest('button');
     expect(foundButton && foundButton.disabled).toBeTruthy();
     // fires the handler properly
-    await waitFor(() => {
-      expect(mockHandler).toBeCalledTimes(1);
-    });
   });
 });

--- a/src/components/AcceptDialog.tsx
+++ b/src/components/AcceptDialog.tsx
@@ -28,6 +28,7 @@ const initialValues = {
 const AcceptDialog: FunctionComponent<Props> = (props) => {
   const [submitError, setSubmitError] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>();
+
   const handleAccept = useCallback(
     async (values: DocumentSubmissionUpdateForm) => {
       try {

--- a/src/components/EvidenceRequestTable.tsx
+++ b/src/components/EvidenceRequestTable.tsx
@@ -37,12 +37,12 @@ export const EvidenceRequestTable: FunctionComponent<Props> = ({
           >
             Requested
           </th>
-          <th
+          {/* <th
             scope="col"
             className="govuk-table__header govuk-table__header--numeric"
           >
             <span className="govuk-visually-hidden">Action</span>
-          </th>
+          </th> */}
         </tr>
       </thead>
 

--- a/src/components/ResidentTable.tsx
+++ b/src/components/ResidentTable.tsx
@@ -40,12 +40,12 @@ export const ResidentTable: FunctionComponent<Props> = ({
           >
             Uploaded
           </th>
-          <th
+          {/* <th
             scope="col"
             className="govuk-table__header govuk-table__header--numeric"
           >
             <span className="govuk-visually-hidden">Action</span>
-          </th>
+          </th> */}
         </tr>
       </thead>
 

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -141,7 +141,10 @@ export class InternalApiGateway {
       );
       return ResponseMapper.mapDocumentSubmission(data);
     } catch (err) {
-      console.error(err);
+      if (err.response) {
+        console.error(err);
+        throw err.response.data;
+      }
       throw new InternalServerError('Internal server error');
     }
   }

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -62,52 +62,6 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   );
   const [isClicked, setIsClicked] = useState(false);
 
-  const handleAccept = useCallback(
-    async (values: DocumentSubmissionUpdateForm) => {
-      try {
-        const payload = buildAcceptDocumentSubmissionRequest(
-          values,
-          user.email
-        );
-        const updated = await gateway.updateDocumentSubmission(
-          user.email,
-          documentSubmissionId,
-          payload
-        );
-        setDocumentSubmission(updated);
-        router.push(
-          `/teams/${teamId}/dashboard/residents/${residentId}`,
-          undefined,
-          { shallow: true }
-        );
-      } catch (err) {
-        console.error(err);
-        setSubmitError(true);
-      }
-    },
-    [documentSubmission]
-  );
-
-  const buildAcceptDocumentSubmissionRequest = (
-    values: DocumentSubmissionUpdateForm,
-    userUpdatedBy: string
-  ) => {
-    if (values.validUntilDates && values.validUntilDates.length > 0) {
-      return {
-        state: values.state,
-        userUpdatedBy: userUpdatedBy,
-        staffSelectedDocumentTypeId: values.staffSelectedDocumentTypeId,
-        validUntil: values.validUntilDates.join('-'),
-      };
-    } else {
-      return {
-        state: values.state,
-        userUpdatedBy: userUpdatedBy,
-        staffSelectedDocumentTypeId: values.staffSelectedDocumentTypeId,
-      };
-    }
-  };
-
   const handleReject = useCallback(
     async (values: DocumentSubmissionUpdateForm) => {
       try {
@@ -257,8 +211,10 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
         <AcceptDialog
           open={acceptDialogOpen}
           staffSelectedDocumentTypes={staffSelectedDocumentTypes}
-          onAccept={handleAccept}
           onDismiss={handleCloseAcceptDialog}
+          email={user.email}
+          documentSubmissionId={documentSubmissionId}
+          redirect={`/teams/${teamId}/dashboard/residents/${residentId}`}
         />
       )}
 


### PR DESCRIPTION
- Displayed the error message coming from the backend APIs
- Refactored document details page and moved the approve functionality on to the `AcceptDialog` component
- Commented out table headers that were visually hidden to remove the unnecessary spaces and improve the UI