### PR TITLE
DES-341: Fix broken ARIA references

### DIFF
--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -27,7 +27,7 @@ const Field = (props: Props): JSX.Element => (
         as="textarea"
         rows="3"
         data-testid="textarea"
-        aria-describedby={props.hint ? `${props.name}-hint` : false}
+        aria-describedby={props.hint ? `${props.name}-hint` : null}
         className={`govuk-textarea  lbh-textarea ${
           props.error ? 'govuk-input--error' : null
         }`}
@@ -36,7 +36,7 @@ const Field = (props: Props): JSX.Element => (
       <FormikField
         name={props.name}
         id={props.name}
-        aria-describedby={props.hint ? `${props.name}-hint` : false}
+        aria-describedby={props.hint ? `${props.name}-hint` : null}
         className={`govuk-input  lbh-input ${
           props.error ? 'govuk-input--error' : null
         }`}


### PR DESCRIPTION
https://hackney.atlassian.net/browse/DES-341

WAVE flags the 3 input boxes with:
> An aria-labelledby or aria-describedby reference exists, but the target for the reference does not exist.

Because the HTML is
`<input name="resident.name" id="resident.name" aria-describedby="false" class="govuk-input lbh-input null" value="">`

Setting the value to `null` instead of `false` if a hint isn't provided fixes this