### PR TITLE
Housing Register access

### DIFF
--- a/auth-groups.json
+++ b/auth-groups.json
@@ -8,11 +8,12 @@
     "Security Testing": "Security_Testing",
     "Electoral Services": "elections-team",
     "Repairs Contact Centre": "repairs-contact-centre-team",
-    "Housing Register": "saml-aws-housing-register-developers"
+    "Housing Register": "housing-needs-collabtools-proto"
   },
   "production": {
     "Development Team": "development-team-production",
     "Electoral Services": "elections-team",
-    "Repairs Contact Centre": "repairs-contact-centre-team"
+    "Repairs Contact Centre": "repairs-contact-centre-team",
+    "Housing Register": "housing-needs-collabtools-proto"
   }
 }

--- a/teams.json
+++ b/teams.json
@@ -74,7 +74,7 @@
   },
   {
     "name": "Housing Register",
-    "googleGroup": "saml-aws-housing-register-developers",
+    "googleGroup": "housing-needs-collabtools-proto",
     "id": "7",
     "reasons": [
       {


### PR DESCRIPTION
Update housing register google group to `housing-needs-collabtools-proto` which is used for Benefits and Housing Needs.