### PR TITLE
Remove whitelisted url and amend error handling

### DIFF
--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -186,9 +186,7 @@ describe('Can view and manage evidence', () => {
       cy.get('button').contains('Yes, accept').click();
 
       //assert
-      cy.get('span')
-        .contains('The date cannot be in the past.')
-        .should('contain', 'The date cannot be in the past.');
+      cy.get('span').eq(0).should('contain', 'The date cannot be in the past.');
     });
   });
 });

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -153,7 +153,7 @@ describe('Can view and manage evidence', () => {
   });
 });
 
-describe('Can view and manage evidence', () => {
+describe('When a user inputs a validity date that is in the past', () => {
   beforeEach(() => {
     cy.login();
 
@@ -170,8 +170,8 @@ describe('Can view and manage evidence', () => {
     cy.contains('h1', 'Namey McName');
   });
 
-  it('shows an error when the validity date is in the past', () => {
-    //arrange user flow
+  it('shows an error', () => {
+    //arrange
     cy.get('a').contains('Proof of ID').click();
     cy.get('button').contains('Accept').click();
 

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -113,6 +113,17 @@ describe('Can view and manage evidence', () => {
     cy.contains('button', 'Request new file').should('not.exist');
   });
 
+  it('shows an error when the validity date is et in the past', () => {
+    cy.intercept('PATCH', '/api/evidence/document_submissions', (req) => {
+      // const response = dsFixture;
+
+      req.responseTimeout = 5000;
+      req.reply((res) => {
+        res.send(400, 'The date cannot be in the past.');
+      });
+    });
+  });
+
   it('can reject the document', () => {
     cy.get('a').contains('Proof of ID').click();
     cy.contains('h1', 'Namey McNameProof of ID');

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -113,17 +113,6 @@ describe('Can view and manage evidence', () => {
     cy.contains('button', 'Request new file').should('not.exist');
   });
 
-  it('shows an error when the validity date is et in the past', () => {
-    cy.intercept('PATCH', '/api/evidence/document_submissions', (req) => {
-      // const response = dsFixture;
-
-      req.responseTimeout = 5000;
-      req.reply((res) => {
-        res.send(400, 'The date cannot be in the past.');
-      });
-    });
-  });
-
   it('can reject the document', () => {
     cy.get('a').contains('Proof of ID').click();
     cy.contains('h1', 'Namey McNameProof of ID');
@@ -161,6 +150,46 @@ describe('Can view and manage evidence', () => {
   it('can view page warning for document with expired claim', () => {
     cy.get('.reviewed a').eq(1).contains('Proof of ID').click();
     cy.get('section').contains('This document is no longer valid');
+  });
+});
+
+describe('Can view and manage evidence', () => {
+  beforeEach(() => {
+    cy.login();
+
+    cy.intercept('PATCH', '/api/evidence/document_submissions', (req) => {
+      req.responseTimeout = 5000;
+      req.reply((res) => {
+        res.send(400, 'The date cannot be in the past.');
+      });
+    }).as('acceptInvalidDate');
+
+    cy.visit(`http://localhost:3000/teams/2/dashboard`);
+
+    cy.get('a').contains('Namey McName').click();
+    cy.contains('h1', 'Namey McName');
+  });
+
+  it('shows an error when the validity date is in the past', () => {
+    //arrange user flow
+    cy.get('a').contains('Proof of ID').click();
+    cy.get('button').contains('Accept').click();
+
+    cy.get('[role=dialog]').within(() => {
+      cy.get('#staffSelectedDocumentTypeId-passport-scan').click();
+
+      cy.get('label').contains('Day').next('input').type('01');
+      cy.get('label').contains('Month').next('input').type('01');
+      cy.get('label').contains('Year').next('input').type('1992');
+
+      //act
+      cy.get('button').contains('Yes, accept').click();
+
+      //assert
+      cy.get('span')
+        .contains('The date cannot be in the past.')
+        .should('contain', 'The date cannot be in the past.');
+    });
   });
 });
 

--- a/src/components/AcceptDialog.tsx
+++ b/src/components/AcceptDialog.tsx
@@ -44,7 +44,7 @@ const AcceptDialog: FunctionComponent<Props> = (props) => {
         );
         router.push(props.redirect, undefined, { shallow: true });
       } catch (err) {
-        console.log(err);
+        console.error(err);
         setSubmitError(true);
         if (err.error) {
           router.push(props.redirect, undefined, { shallow: true });

--- a/src/components/AcceptDialog.tsx
+++ b/src/components/AcceptDialog.tsx
@@ -44,12 +44,11 @@ const AcceptDialog: FunctionComponent<Props> = (props) => {
         );
         router.push(props.redirect, undefined, { shallow: true });
       } catch (err) {
+        console.log(err);
         setSubmitError(true);
-        if (typeof err == 'object') {
-          console.error(err.error);
+        if (err.error) {
           router.push(props.redirect, undefined, { shallow: true });
         } else {
-          console.error(err);
           setErrorMessage(err);
         }
       }

--- a/src/components/AcceptDialog.tsx
+++ b/src/components/AcceptDialog.tsx
@@ -44,9 +44,14 @@ const AcceptDialog: FunctionComponent<Props> = (props) => {
         );
         router.push(props.redirect, undefined, { shallow: true });
       } catch (err) {
-        console.error(err);
         setSubmitError(true);
-        setErrorMessage(err);
+        if (typeof err == 'object') {
+          console.error(err.error);
+          router.push(props.redirect, undefined, { shallow: true });
+        } else {
+          console.error(err);
+          setErrorMessage(err);
+        }
       }
     },
     [setErrorMessage, setSubmitError]

--- a/src/services/request-authorizer.ts
+++ b/src/services/request-authorizer.ts
@@ -18,7 +18,6 @@ const AUTH_WHITELIST = [
   '/resident/*/confirmation',
   '/evidence_requests/*',
   '/evidence_requests/*/document_submissions',
-  '/document_submissions/*',
 ].map((str) => new RegExp(`^${str.replace('*', GLOB)}$`));
 
 export interface RequestAuthorizerCommand {


### PR DESCRIPTION
**Ticket**
https://hackney.atlassian.net/browse/DOC-537

**Problem**
In this issue, a user could approve their own uploaded documents by intercepting the request and changing the body to "status: approved". This is because the document_submission url was whitelisted from Google Auth, meaning that an unauthenticated user could access that URL. You could practice this locally by removing the auth token before you hit "Submit" when approving a document.

**Solution**
We removed the URL from the whitelist and configured the error handling so that the user is redirected to the login page when they are missing their token.

**Tests**
We have also added in an acceptance (Cypress) test to check that if a user submits a validity date that is in the past, then the correct error shows up.

The tests to check if a user is authenticated or not are already included in the test suite.