### PR TITLE
Add full list of accepted mime types

### DIFF
--- a/src/components/UploaderPanel.tsx
+++ b/src/components/UploaderPanel.tsx
@@ -8,6 +8,30 @@ const classNameFromProps = (props: Props) => {
   return className;
 };
 
+const acceptedMimeTypes = (): string => {
+  const acceptedMimeTypes = [
+    'application/msword',
+    'application/octet-stream',
+    'application/pdf',
+    'application/vnd.apple.numbers',
+    'application/vnd.apple.pages',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'image/bmp',
+    'image/gif',
+    'image/heic',
+    'image/jpeg',
+    'image/png',
+    'text/plain',
+    //'video/3gpp',
+    //'video/mp4',
+    //'video/quicktime',
+  ];
+
+  return acceptedMimeTypes.join(',');
+};
+
 const UploaderPanel: FunctionComponent<Props> = (props) => (
   <div className={classNameFromProps(props)}>
     <label className="govuk-label lbh-label" htmlFor={props.name}>
@@ -29,7 +53,7 @@ const UploaderPanel: FunctionComponent<Props> = (props) => (
       name={props.name}
       id={props.name}
       data-testid="fileInput"
-      accept="image/*,application/pdf,video/*"
+      accept={acceptedMimeTypes()}
       onChange={(e) => {
         if (e.currentTarget.files !== null) {
           props.setFieldValue(props.name, Array.from(e.currentTarget.files));

--- a/src/components/UploaderPanel.tsx
+++ b/src/components/UploaderPanel.tsx
@@ -10,23 +10,22 @@ const classNameFromProps = (props: Props) => {
 
 const acceptedMimeTypes = (): string => {
   const acceptedMimeTypes = [
-    'application/msword',
-    'application/octet-stream',
-    'application/pdf',
-    'application/vnd.apple.numbers',
-    'application/vnd.apple.pages',
-    'application/vnd.ms-excel',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'image/bmp',
-    'image/gif',
-    'image/heic',
-    'image/jpeg',
-    'image/png',
-    'text/plain',
-    //'video/3gpp',
-    //'video/mp4',
-    //'video/quicktime',
+    'application/msword', //.doc
+    'application/pdf', //.pdf
+    'application/vnd.apple.numbers', //.numbers
+    'application/vnd.apple.pages', //.pages
+    'application/vnd.ms-excel', //.xls
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', //.xlsx
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document', //.docx
+    'image/bmp', //.bmp
+    'image/gif', //.gif
+    'image/heic', //.heic
+    'image/jpeg', //.jpeg or .jpg
+    'image/png', //.png
+    'text/plain', //.txt
+    //'video/3gpp', //.3gpp or .3gp
+    //'video/mp4', //.mp4
+    //'video/quicktime', //.mov or .qt
   ];
 
   return acceptedMimeTypes.join(',');


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-542

## Describe this PR

### What is the problem we're trying to solve

From the security test, we identified that we needed to whitelist file extensions/mime types when the API receives a request. This list can be quite long, so we've refactored it to make it easier for future developers to remove/add mime types.

## What changes have we introduced

A new file with all accepted mime types.