### PR TITLE
Create file format details component and add it on the upload page

### DIFF
--- a/cypress/integration/upload-a-document.spec.ts
+++ b/cypress/integration/upload-a-document.spec.ts
@@ -39,6 +39,13 @@ describe('Can upload a document', () => {
 
       // Attach a file
       cy.get('h1').should('contain', 'Upload your documents');
+      cy.get('[data-testid=file-formats-details-title]')
+        .should('contain', 'Which file formats are accepted?')
+        .click();
+      cy.get('[data-testid=file-formats-details-text]').should(
+        'contain',
+        'We currently support the following formats:'
+      );
       cy.get('input[type=file]').each((input) =>
         cy.wrap(input).attachFile('example.png')
       );

--- a/src/components/FileFormatsDetails.tsx
+++ b/src/components/FileFormatsDetails.tsx
@@ -1,0 +1,25 @@
+import React, { FunctionComponent } from 'react';
+
+const FileFormatDetails: FunctionComponent = () => (
+  <details className="govuk-details lbh-details" data-module="govuk-details">
+    <summary className="govuk-details__summary">
+      <span
+        className="govuk-details__summary-text"
+        data-testid="file-formats-details-title"
+      >
+        Which file formats are accepted?
+      </span>
+    </summary>
+    <div
+      className="govuk-details__text"
+      data-testid="file-formats-details-text"
+    >
+      <strong>We currently support the following formats:</strong>
+      <br />
+      .doc, .pdf, .numbers, .pages, .xls, .xlsx, .docx, .bmp, .gif, .heic, .jpeg
+      or .jpg, .png, .txt
+    </div>
+  </details>
+);
+
+export default FileFormatDetails;

--- a/src/pages/resident/[requestId]/upload.tsx
+++ b/src/pages/resident/[requestId]/upload.tsx
@@ -7,6 +7,7 @@ import { EvidenceApiGateway } from 'src/gateways/evidence-api';
 import Layout from '../../../components/ResidentLayout';
 import UploaderForm from '../../../components/UploaderForm';
 import { Constants } from '../../../helpers/Constants';
+import FileFormatDetails from 'src/components/FileFormatsDetails';
 
 type UploadProps = {
   requestId: string;
@@ -41,6 +42,7 @@ const Upload: NextPage<UploadProps> = ({
           <p className="lbh-body">
             Upload a photograph or scan for the following evidence.
           </p>
+          <FileFormatDetails />
           <UploaderForm
             evidenceRequestId={evidenceRequestId}
             documentTypes={documentTypes}


### PR DESCRIPTION
Link to Jira card: 
https://hackney.atlassian.net/browse/DOC-545

- Added a new component FileFormatsDetails
- Added the component on the upload page to show our users the file extensions that we currently accept in the system
- Updated the cypress tests to check for the new component on the screen