### PR TITLE
Change download document page to use presigned url instead of base64

### DIFF
--- a/src/gateways/documents-api.test.ts
+++ b/src/gateways/documents-api.test.ts
@@ -44,4 +44,28 @@ describe('Documents api gateway', () => {
       });
     });
   });
+
+  describe('GET request to /claims/{claimId}/download_links', () => {
+    const claimId = '123-abc-claimId';
+    const expectedData = 'www.downloadlinkfordocument.com';
+    const expectedStatus = 200;
+    const expectedResponse = { data: expectedData, status: expectedStatus };
+
+    beforeEach(() => {
+      client.get.mockResolvedValue({ data: expectedResponse });
+    });
+
+    it('the request returns the correct response', async () => {
+      const response = await gateway.getDocumentFromUrl(claimId);
+      expect(response).toEqual(expectedResponse);
+      expect(client.get).toHaveBeenCalledWith(
+        `/api/v1/claims/${claimId}/download_links`,
+        {
+          headers: {
+            Authorization: process.env.DOCUMENTS_API_GET_DOCUMENTS_TOKEN,
+          },
+        }
+      );
+    });
+  });
 });

--- a/src/gateways/documents-api.test.ts
+++ b/src/gateways/documents-api.test.ts
@@ -56,7 +56,7 @@ describe('Documents api gateway', () => {
     });
 
     it('the request returns the correct response', async () => {
-      const response = await gateway.getDocumentFromUrl(claimId);
+      const response = await gateway.getDocumentPreSignedUrl(claimId);
       expect(response).toEqual(expectedResponse);
       expect(client.get).toHaveBeenCalledWith(
         `/api/v1/claims/${claimId}/download_links`,

--- a/src/gateways/documents-api.test.ts
+++ b/src/gateways/documents-api.test.ts
@@ -67,5 +67,17 @@ describe('Documents api gateway', () => {
         }
       );
     });
+
+    describe('when there is an error', () => {
+      it('returns internal server error', async () => {
+        client.get.mockRejectedValue(new Error('Network error'));
+        expect.assertions(1);
+        try {
+          await gateway.getDocumentPreSignedUrl(claimId);
+        } catch (err) {
+          expect(err).toEqual(new InternalServerError('Internal server error'));
+        }
+      });
+    });
   });
 });

--- a/src/gateways/documents-api.ts
+++ b/src/gateways/documents-api.ts
@@ -38,7 +38,7 @@ export class DocumentsApiGateway {
     }
   }
 
-  async getDocumentFromUrl(claimId: string): Promise<string> {
+  async getDocumentPreSignedUrl(claimId: string): Promise<string> {
     try {
       const { data } = await this.client.get<string>(
         `/api/v1/claims/${claimId}/download_links`,

--- a/src/gateways/documents-api.ts
+++ b/src/gateways/documents-api.ts
@@ -37,4 +37,19 @@ export class DocumentsApiGateway {
       throw new InternalServerError('Internal server error');
     }
   }
+
+  async getDocumentFromUrl(claimId: string): Promise<string> {
+    try {
+      const { data } = await this.client.get<string>(
+        `/api/v1/claims/${claimId}/download_links`,
+        {
+          headers: { Authorization: tokens?.documents?.GET },
+        }
+      );
+      return data;
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerError('Internal server error');
+    }
+  }
 }

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -35,7 +35,7 @@ type DocumentDetailPageProps = {
   resident: Resident;
   documentSubmission: DocumentSubmission;
   staffSelectedDocumentTypes: DocumentType[];
-  documentAsBase64: string;
+  downloadUrl: string;
   feedbackUrl: string;
 };
 
@@ -45,7 +45,7 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
   resident,
   documentSubmission: _documentSubmission,
   staffSelectedDocumentTypes,
-  documentAsBase64,
+  downloadUrl,
   feedbackUrl,
 }) => {
   const router = useRouter();
@@ -150,11 +150,11 @@ const DocumentDetailPage: NextPage<WithUser<DocumentDetailPageProps>> = ({
       <figure className={styles.preview}>
         {document.extension === 'jpeg' || document.extension === 'png' ? (
           <img
-            src={`${documentAsBase64}`}
+            src={`${downloadUrl}`}
             alt={documentSubmission.documentType.title}
           />
         ) : (
-          <iframe src={`${documentAsBase64}`} height="1000px" width="800px" />
+          <iframe src={`${downloadUrl}`} height="1000px" width="800px" />
         )}
         <figcaption className="lbh-body-s">
           <strong>{document.extension?.toUpperCase()}</strong>{' '}
@@ -229,10 +229,10 @@ export const getServerSideProps = withAuth(async (ctx) => {
   );
   const resident = await evidenceApiGateway.getResident(user.email, residentId);
 
-  let documentAsBase64 = '';
+  let downloadUrl = '';
   if (documentSubmission && documentSubmission.document) {
-    documentAsBase64 = await documentsApiGateway.getDocument(
-      documentSubmission.document.id
+    downloadUrl = await documentsApiGateway.getDocumentPreSignedUrl(
+      documentSubmission.claimId
     );
   }
   return {
@@ -242,7 +242,7 @@ export const getServerSideProps = withAuth(async (ctx) => {
       resident,
       documentSubmission,
       staffSelectedDocumentTypes,
-      documentAsBase64,
+      downloadUrl,
       feedbackUrl,
     },
   };

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/document/[documentSubmissionId].tsx
@@ -230,7 +230,7 @@ export const getServerSideProps = withAuth(async (ctx) => {
   const resident = await evidenceApiGateway.getResident(user.email, residentId);
 
   let downloadUrl = '';
-  if (documentSubmission && documentSubmission.document) {
+  if (documentSubmission && documentSubmission.claimId) {
     downloadUrl = await documentsApiGateway.getDocumentPreSignedUrl(
       documentSubmission.claimId
     );

--- a/test/mocks/behaviours.json
+++ b/test/mocks/behaviours.json
@@ -18,7 +18,8 @@
       "get-document-submissions-with-expired-claim",
       "get-resident",
       "get-document",
-      "get-base64-document"
+      "get-base64-document",
+      "get-download-url"
     ]
   }
 ]

--- a/test/mocks/fixtures/get-download-url.js
+++ b/test/mocks/fixtures/get-download-url.js
@@ -1,0 +1,14 @@
+const getDownloadUrl = {
+  id: 'get-download-url',
+  url: '/api/v1/claims/:id/download_links',
+  method: 'GET',
+  response: {
+    status: 200,
+    body:
+      'https://upload.wikimedia.org/wikipedia/en/thumb/9/90/Lb_hackney_logo.svg/2880px-Lb_hackney_logo.svg.png',
+  },
+};
+
+module.exports = {
+  getDownloadUrl,
+};


### PR DESCRIPTION
The link to JIRA ticket is here: https://hackney.atlassian.net/browse/DOC-614

The purpose of this feature is to implement the new download path from S3 on the frontend. Instead of retrieving the document as a base64 encoding, the FE now calls documents api that returns a presigned url from S3.

In this PR, we've added a new gateway to get the download link from documents api and renders the document using this url on the page.