### PR TITLE
Add Leasehold and Right To Buy group to staging

### DIFF
--- a/auth-groups.json
+++ b/auth-groups.json
@@ -7,7 +7,8 @@
     "Security Testing": "Security_Testing",
     "Housing Register": "Housing Register",
     "Document Products Team": "Document-Products-Team-All-Team-Access-Group",
-    "Staging Demo Team": "Document Evidence Service - Test and Development"
+    "Staging Demo Team": "Document Evidence Service - Test and Development",
+    "Leasehold and Right to Buy": "Leasehold and Right to Buy"
   },
   "production": {
     "Development Team": "development-team-production",

--- a/teams.json
+++ b/teams.json
@@ -114,5 +114,18 @@
     ],
     "landingMessage": "Housing Register",
     "slaMessage": "Thank you. Your documents have been uploaded."
+  },
+  {
+    "name": "Leasehold and Right to Buy",
+    "googleGroup": "Leasehold and Right to Buy",
+    "id": "8",
+    "reasons": [
+      {
+        "name": "This is a holding reason",
+        "id": "1"
+      }
+    ],
+    "landingMessage": "This is the Leasehold and Right to Buy's landing message",
+    "slaMessage": "This is the Leasehold and Right to Buy's SLA message."
   }
 ]


### PR DESCRIPTION
Linked to this ticket: https://hackney.atlassian.net/browse/DOC-564

In this PR, we just needed to add the Google group that Lewis has created to the frontend config. I've tested this locally and I can access the group (once I cleared my cookies and logged back in again).