### PR TITLE
Add datetime to doc submissions on residents page

### DIFF
--- a/cypress/fixtures/document_submissions/get-approved.json
+++ b/cypress/fixtures/document_submissions/get-approved.json
@@ -10,7 +10,7 @@
     "description": "A valid passport open at the photo page"
   },
   "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
-  "createdAt": "2021-01-14T10:23:42.958Z",
+  "createdAt": "2020-12-25T10:23:42.958Z",
   "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
   "claimValidUntil": "2121-01-29T16:28:11.326Z",
   "retentionExpiresAt": "2021-04-14T10:23:42.958Z",

--- a/cypress/fixtures/document_submissions/get-many.json
+++ b/cypress/fixtures/document_submissions/get-many.json
@@ -51,7 +51,7 @@
       "description": "Any valid proof of id"
     },
     "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
-    "createdAt": "2021-01-14T10:23:42.958Z",
+    "createdAt": "2020-12-25T10:23:42.958Z",
     "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
     "claimValidUntil": "2121-01-29T16:28:11.326Z",
     "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
@@ -71,7 +71,7 @@
       "description": "A valid document that can be used to prove identity"
     },
     "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
-    "createdAt": "2021-01-14T10:23:42.958Z",
+    "createdAt": "2020-12-30T10:23:42.958Z",
     "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
     "claimValidUntil": "2121-01-29T16:28:11.326Z",
     "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
@@ -98,7 +98,7 @@
       "description": "Any valid proof of id"
     },
     "id": "c82120d2-0a5c-4f40-bdcd-5a18d877344v",
-    "createdAt": "2021-01-14T10:23:42.958Z",
+    "createdAt": "2020-12-25T10:23:42.958Z",
     "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
     "claimValidUntil": "2000-01-29T16:28:11.326Z",
     "retentionExpiresAt": "2021-04-14T10:23:42.958Z",

--- a/cypress/fixtures/document_submissions/get-rejected.json
+++ b/cypress/fixtures/document_submissions/get-rejected.json
@@ -5,7 +5,7 @@
     "description": "A valid document that can be used to prove identity"
   },
   "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
-  "createdAt": "2021-01-14T10:23:42.958Z",
+  "createdAt": "2020-12-30T10:23:42.958Z",
   "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
   "claimValidUntil": "2121-01-29T16:28:11.326Z",
   "retentionExpiresAt": "2021-04-14T10:23:42.958Z",

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -42,6 +42,21 @@ describe('Can view and manage evidence', () => {
     cy.get('.rejected a').eq(0).should('contain', 'Proof of ID');
   });
 
+  it('shows the correct date format', () => {
+    cy.get('.toReview p').should(
+      'contain',
+      '10:23 14 January 2021 (last year)'
+    );
+    cy.get('.reviewed p').should(
+      'contain',
+      '10:23 25 December 2020 (2 years ago)'
+    );
+    cy.get('.rejected p').should(
+      'contain',
+      '10:23 30 December 2020 (2 years ago)'
+    );
+  });
+
   it('lets you see an image document detail page with actions and information', () => {
     cy.get('.toReview a').eq(0).contains('Proof of ID').click();
 

--- a/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
+++ b/src/pages/teams/[teamId]/dashboard/residents/[residentId]/index.tsx
@@ -9,7 +9,7 @@ import { EvidenceList, EvidenceTile } from 'src/components/EvidenceTile';
 import { withAuth, WithUser } from 'src/helpers/authed-server-side-props';
 import { RequestAuthorizer } from '../../../../../../services/request-authorizer';
 import { TeamHelper } from '../../../../../../services/team-helper';
-import { formatRelativeCalendarDate } from '../../../../../../helpers/formatters';
+import { formatDate } from '../../../../../../helpers/formatters';
 import SVGSymbol from 'src/components/SVGSymbol';
 
 type ResidentPageProps = {
@@ -73,7 +73,7 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
                 key={ds.id}
                 id={ds.id}
                 title={String(ds.documentType.title)}
-                createdAt={formatRelativeCalendarDate(ds.createdAt)}
+                createdAt={formatDate(ds.createdAt)}
                 fileSizeInBytes={ds.document ? ds.document.fileSizeInBytes : 0}
                 format={ds.document ? ds.document.extension : 'unknown'}
                 // purpose="Example form"
@@ -102,7 +102,7 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
                 key={ds.id}
                 id={ds.id}
                 title={String(ds.staffSelectedDocumentType?.title)}
-                createdAt={formatRelativeCalendarDate(ds.createdAt)}
+                createdAt={formatDate(ds.createdAt)}
                 fileSizeInBytes={ds.document ? ds.document.fileSizeInBytes : 0}
                 format={ds.document ? ds.document.extension : 'unknown'}
                 // purpose="Example form"
@@ -129,7 +129,7 @@ const ResidentPage: NextPage<WithUser<ResidentPageProps>> = ({
                 key={ds.id}
                 id={ds.id}
                 title={String(ds.documentType.title)}
-                createdAt={formatRelativeCalendarDate(ds.createdAt)}
+                createdAt={formatDate(ds.createdAt)}
                 fileSizeInBytes={ds.document ? ds.document.fileSizeInBytes : 0}
                 format={ds.document ? ds.document.extension : 'unknown'}
                 // purpose="Example form"


### PR DESCRIPTION
Affects this ticket: https://hackney.atlassian.net/browse/DOC-839

HR requested that we include the full date on document submissions on the residents page for auditing purposes.

In this PR, I've changed the formatting of the date using an existing formatter method we had, and tweaked some of the fixtures to check that we were testing the right dates.