### PR TITLE
Add call to evidence-api to send a confirmation notification to resident

### DIFF
--- a/src/gateways/internal-api.test.ts
+++ b/src/gateways/internal-api.test.ts
@@ -348,4 +348,45 @@ describe('Internal API Gateway', () => {
       });
     });
   });
+
+  describe('sendUploadConfirmationNotificationToResident', () => {
+    const evidenceRequestId = 'evidence request id';
+
+    describe('when successful', () => {
+      beforeEach(() => {
+        client.post.mockResolvedValue({
+          data: {},
+        });
+      });
+
+      it('makes the api request', async () => {
+        await gateway.sendUploadConfirmationNotificationToResident(
+          Constants.DUMMY_EMAIL,
+          evidenceRequestId
+        );
+
+        expect(
+          client.post
+        ).toHaveBeenCalledWith(
+          `/api/evidence/evidence_requests/${evidenceRequestId}/confirmation`,
+          null,
+          { headers: { UserEmail: Constants.DUMMY_EMAIL } }
+        );
+      });
+    });
+
+    describe('when there is an error', () => {
+      it('returns internal server error', async () => {
+        client.post.mockRejectedValue(new Error('Internal server error'));
+        const functionCall = () =>
+          gateway.sendUploadConfirmationNotificationToResident(
+            Constants.DUMMY_EMAIL,
+            evidenceRequestId
+          );
+        await expect(functionCall).rejects.toEqual(
+          new InternalServerError('Internal server error')
+        );
+      });
+    });
+  });
 });

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -194,4 +194,24 @@ export class InternalApiGateway {
       throw new InternalServerError('Internal server error');
     }
   }
+
+  async sendUploadConfirmationNotificationToResident(
+    userEmail: string,
+    evidenceRequestId: string
+  ): Promise<void> {
+    try {
+      await this.client.post<void>(
+        `/api/evidence/evidence_requests/${evidenceRequestId}/confirmation`,
+        null,
+        {
+          headers: {
+            UserEmail: userEmail,
+          },
+        }
+      );
+    } catch (err) {
+      console.error(err);
+      throw new InternalServerError('Internal server error');
+    }
+  }
 }

--- a/src/services/request-authorizer.ts
+++ b/src/services/request-authorizer.ts
@@ -17,6 +17,7 @@ const AUTH_WHITELIST = [
   '/resident/*/upload',
   '/resident/*/confirmation',
   '/evidence_requests/*',
+  '/evidence_requests/*/confirmation',
   '/evidence_requests/*/document_submissions',
 ].map((str) => new RegExp(`^${str.replace('*', GLOB)}$`));
 

--- a/src/services/upload-form-model.test.ts
+++ b/src/services/upload-form-model.test.ts
@@ -19,9 +19,11 @@ const evidenceRequest = ResponseMapper.mapEvidenceRequest(
 const evidenceRequestId = evidenceRequest.id;
 
 const mockCreateDocumentSubmission = jest.fn(() => documentSubmission);
+const mockSendUploadConfirmationNotificationToResident = jest.fn();
 jest.mock('../gateways/internal-api', () => ({
   InternalApiGateway: jest.fn(() => ({
     createDocumentSubmission: mockCreateDocumentSubmission,
+    sendUploadConfirmationNotificationToResident: mockSendUploadConfirmationNotificationToResident,
   })),
 }));
 
@@ -110,6 +112,13 @@ describe('UploadFormModel', () => {
         fileList2[1],
         documentSubmission.uploadPolicy
       );
+    });
+
+    it('sends a confirmation to the resident after upload is successful', async () => {
+      await model.handleSubmit(values, evidenceRequestId);
+      expect(
+        mockSendUploadConfirmationNotificationToResident
+      ).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/upload-form-model.ts
+++ b/src/services/upload-form-model.ts
@@ -56,6 +56,10 @@ export class UploadFormModel {
     });
 
     await Promise.all(createDocumentSubmissionAndUploadForEachFile);
+    await this.gateway.sendUploadConfirmationNotificationToResident(
+      Constants.DUMMY_EMAIL,
+      evidenceRequestId
+    );
   }
 
   private async uploadFile(file: File, documentSubmission: DocumentSubmission) {


### PR DESCRIPTION
Link to Jira card: https://hackney.atlassian.net/browse/DOC-870

- Added a call to evidence-api so that after each successful upload of documents the resident receives a confirmation by email/SMS
- Added tests