### PR TITLE
Rename method as endpoint now has added functionality

### DIFF
--- a/src/gateways/internal-api.test.ts
+++ b/src/gateways/internal-api.test.ts
@@ -349,7 +349,7 @@ describe('Internal API Gateway', () => {
     });
   });
 
-  describe('sendUploadConfirmationNotificationToResident', () => {
+  describe('sendUploadConfirmationNotificationToResidentAndStaff', () => {
     const evidenceRequestId = 'evidence request id';
 
     describe('when successful', () => {
@@ -360,7 +360,7 @@ describe('Internal API Gateway', () => {
       });
 
       it('makes the api request', async () => {
-        await gateway.sendUploadConfirmationNotificationToResident(
+        await gateway.sendUploadConfirmationNotificationToResidentAndStaff(
           Constants.DUMMY_EMAIL,
           evidenceRequestId
         );
@@ -379,7 +379,7 @@ describe('Internal API Gateway', () => {
       it('returns internal server error', async () => {
         client.post.mockRejectedValue(new Error('Internal server error'));
         const functionCall = () =>
-          gateway.sendUploadConfirmationNotificationToResident(
+          gateway.sendUploadConfirmationNotificationToResidentAndStaff(
             Constants.DUMMY_EMAIL,
             evidenceRequestId
           );

--- a/src/gateways/internal-api.ts
+++ b/src/gateways/internal-api.ts
@@ -195,7 +195,7 @@ export class InternalApiGateway {
     }
   }
 
-  async sendUploadConfirmationNotificationToResident(
+  async sendUploadConfirmationNotificationToResidentAndStaff(
     userEmail: string,
     evidenceRequestId: string
   ): Promise<void> {

--- a/src/services/upload-form-model.test.ts
+++ b/src/services/upload-form-model.test.ts
@@ -19,11 +19,11 @@ const evidenceRequest = ResponseMapper.mapEvidenceRequest(
 const evidenceRequestId = evidenceRequest.id;
 
 const mockCreateDocumentSubmission = jest.fn(() => documentSubmission);
-const mockSendUploadConfirmationNotificationToResident = jest.fn();
+const mockSendUploadConfirmationNotificationToResidentAndStaff = jest.fn();
 jest.mock('../gateways/internal-api', () => ({
   InternalApiGateway: jest.fn(() => ({
     createDocumentSubmission: mockCreateDocumentSubmission,
-    sendUploadConfirmationNotificationToResident: mockSendUploadConfirmationNotificationToResident,
+    sendUploadConfirmationNotificationToResidentAndStaff: mockSendUploadConfirmationNotificationToResidentAndStaff,
   })),
 }));
 
@@ -117,7 +117,7 @@ describe('UploadFormModel', () => {
     it('sends a confirmation to the resident after upload is successful', async () => {
       await model.handleSubmit(values, evidenceRequestId);
       expect(
-        mockSendUploadConfirmationNotificationToResident
+        mockSendUploadConfirmationNotificationToResidentAndStaff
       ).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/services/upload-form-model.ts
+++ b/src/services/upload-form-model.ts
@@ -56,7 +56,7 @@ export class UploadFormModel {
     });
 
     await Promise.all(createDocumentSubmissionAndUploadForEachFile);
-    await this.gateway.sendUploadConfirmationNotificationToResident(
+    await this.gateway.sendUploadConfirmationNotificationToResidentAndStaff(
       Constants.DUMMY_EMAIL,
       evidenceRequestId
     );


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-906

## Describe this PR

### *What is the problem we're trying to solve*
Following on from the [story](https://hackney.atlassian.net/browse/DOC-871) to reduce the amount of emails sent to the Hackney staff member, we decided to send a request for the email to be sent when the resident has uploaded the documents. This feature uses an endpoint created in a previous feature that sends a confirmation code to the resident. I've amended this in Evidence API so that it also sends an email to the staff member.

### *What changes have we introduced*
This PR changes the name of this method on the FE to accurately reflect the changes in the API.


#### _Checklist_
- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*
Approve the Evidence API code. 