### PR TITLE
Guidance for more options on how to upload documents for residents

### DIFF
--- a/cypress/integration/upload-a-document.spec.ts
+++ b/cypress/integration/upload-a-document.spec.ts
@@ -33,28 +33,35 @@ describe('Can upload a document', () => {
       }).as('s3Upload');
     });
 
-    it('shows guidance and lets you upload a file', () => {
-      // View guidance
-      cy.get('h1').should(
-        'contain',
-        'You’ll need to photograph your documents'
-      );
+    it('shows landing message, check guidance and lets you upload a file', () => {
+      // View landing message
+      cy.get('h1').should('contain', 'Please have your documents ready');
       cy.get('p').should('contain', `${teams[1].landingMessage}`);
       cy.get('a').contains('Continue').click();
 
-      // Attach a file
+      // Check guidance
       cy.get('h1').should('contain', 'Upload your documents');
+
+      cy.get('[data-testid=photo-info-details-title]')
+        .should('contain', 'How to photograph your documents')
+        .click();
+      cy.get('[data-testid=photo-info-details-text]').should(
+        'contain',
+        'You can use your smartphone camera. First, make sure you’re in a well-lit place.'
+      );
       cy.get('[data-testid=file-formats-details-title]')
         .should('contain', 'Which file formats are accepted?')
         .click();
-      cy.get('[data-testid=select-multiple-files-guidance]').should(
-        'contain',
-        `After clicking the "Choose files" button, you can use the Ctrl key (Command key on a Mac machine) + click to select multiple files.`
-      );
       cy.get('[data-testid=file-formats-details-text]').should(
         'contain',
         'We currently support the following formats:'
       );
+      cy.get('[data-testid=select-multiple-files-guidance]').should(
+        'contain',
+        `After clicking the "Choose files" button, you can use the Ctrl key (Command key on a Mac machine) + click to select multiple files.`
+      );
+
+      //Attach a file
       cy.get('input[type=file]').each((input) =>
         cy.wrap(input).attachFile('example.png')
       );
@@ -74,24 +81,28 @@ describe('Can upload a document', () => {
       cy.get('p').should('contain', `${teams[1].slaMessage}`);
     });
 
-    it('shows guidance and lets you upload multiple files for each document type', () => {
-      // View guidance
-      cy.get('h1').should(
-        'contain',
-        'You’ll need to photograph your documents'
-      );
+    it('shows landing message, view guidance and lets you upload multiple files for each document type', () => {
+      // View landing message
+      cy.get('h1').should('contain', 'Please have your documents ready');
       cy.get('p').should('contain', `${teams[1].landingMessage}`);
       cy.get('a').contains('Continue').click();
 
-      // Attach a file
+      // View guidance
       cy.get('h1').should('contain', 'Upload your documents');
-      cy.get('[data-testid=file-formats-details-title]')
-        .should('contain', 'Which file formats are accepted?')
-        .click();
+      cy.get('[data-testid=photo-info-details-title]').should(
+        'contain',
+        'How to photograph your documents'
+      );
+      cy.get('[data-testid=file-formats-details-title]').should(
+        'contain',
+        'Which file formats are accepted?'
+      );
       cy.get('[data-testid=select-multiple-files-guidance]').should(
         'contain',
         `After clicking the "Choose files" button, you can use the Ctrl key (Command key on a Mac machine) + click to select multiple files.`
       );
+
+      //Attach a file
       cy.get('input[type=file]').each((input) => {
         cy.wrap(input).attachFile('example.png').attachFile('example.png');
       });

--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -201,7 +201,9 @@ describe('When a user inputs a validity date that is in the past', () => {
       cy.get('button').contains('Yes, accept').click();
 
       //assert
-      cy.get('span').eq(0).should('contain', 'The date cannot be in the past.');
+      cy.get('fieldset>span')
+        .eq(0)
+        .should('contain', 'The date cannot be in the past.');
     });
   });
 });

--- a/src/components/PhotoInformation.tsx
+++ b/src/components/PhotoInformation.tsx
@@ -1,0 +1,26 @@
+import React, { FunctionComponent } from 'react';
+
+const FileFormatDetails: FunctionComponent = () => (
+  <details className="govuk-details lbh-details" data-module="govuk-details">
+    <summary className="govuk-details__summary">
+      <span
+        className="govuk-details__summary-text"
+        data-testid="photo-info-details-title"
+      >
+        How to photograph your documents
+      </span>
+    </summary>
+    <div className="govuk-details__text" data-testid="photo-info-details-text">
+      <p className="lbh-body">
+        You can use your smartphone camera. First, make sure you’re in a
+        well-lit place.
+      </p>
+      <p className="lbh-body">
+        Lie the document flat and try not to cover any part of it.
+      </p>
+      <p className="lbh-body">Make sure the whole document is in the frame.</p>
+    </div>
+  </details>
+);
+
+export default FileFormatDetails;

--- a/src/pages/resident/[requestId]/index.tsx
+++ b/src/pages/resident/[requestId]/index.tsx
@@ -19,24 +19,12 @@ const Index: NextPage<IndexProps> = ({ requestId, team }) => {
     <Layout feedbackUrl={process.env.FEEDBACK_FORM_RESIDENT_URL as string}>
       <Head>
         <title>
-          You’ll need to photograph your documents | Document Evidence Service |
-          Hackney Council
+          Please have your documents ready | Document Evidence Service | Hackney
+          Council
         </title>
       </Head>
       <InterruptionCard>
-        <h1 className="lbh-heading-h1">
-          You’ll need to photograph your documents
-        </h1>
-        <p className="lbh-body">
-          You can use your smartphone camera. First, make sure you’re in a
-          well-lit place.
-        </p>
-        <p className="lbh-body">
-          Lie the document flat and try not to cover any part of it.
-        </p>
-        <p className="lbh-body">
-          Make sure the whole document is in the frame.
-        </p>
+        <h1 className="lbh-heading-h1">Please have your documents ready</h1>
         <p className="lbh-body">{team.landingMessage}</p>
         <Link href={`/resident/${requestId}/upload`}>
           <a className="govuk-button lbh-button">Continue</a>

--- a/src/pages/resident/[requestId]/upload.tsx
+++ b/src/pages/resident/[requestId]/upload.tsx
@@ -8,6 +8,7 @@ import Layout from '../../../components/ResidentLayout';
 import UploaderForm from '../../../components/UploaderForm';
 import { Constants } from '../../../helpers/Constants';
 import FileFormatDetails from 'src/components/FileFormatsDetails';
+import PhotoInformation from 'src/components/PhotoInformation';
 
 type UploadProps = {
   requestId: string;
@@ -36,12 +37,20 @@ const Upload: NextPage<UploadProps> = ({
       </Head>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <h1 className="lbh-heading-h1">
-            Upload your {documentTypes?.length > 1 ? 'documents' : 'document'}
-          </h1>
+          <h1 className="lbh-heading-h1">Upload your documents</h1>
           <p className="lbh-body">
-            Upload a photograph or scan for the following evidence.
+            Before you start, make sure that all the files you need are stored
+            on this device.
           </p>
+          <p className="govuk-body govuk-!-font-weight-bold">
+            You can provide evidence by:
+          </p>
+          <ul className="lbh-list lbh-list--bullet govuk-!-margin-top-2">
+            <li>Photographing your documents</li>
+            <li>Scanning your documents</li>
+            <li>Uploading existing evidence</li>
+          </ul>
+          <PhotoInformation />
           <FileFormatDetails />
           <div
             className="govuk-inset-text"


### PR DESCRIPTION
Refers to this ticket: https://hackney.atlassian.net/browse/DOC-851

In this commit, I've updated the landing page and moved the photography guidance text that was there onto the upload page.
<img width="993" alt="Screenshot 2022-07-15 at 16 37 55" src="https://user-images.githubusercontent.com/56876663/179246338-408737a8-1e98-4200-815d-268f36dd9881.png">

On the upload page, I've added guidance for alternate options for uploading documents. I also removed the function to pluralise the 'Document' in the title, because even if one document type was requested, a resident can still upload multiple documents (plus it's consistent with all the other refs to documents on the page).
<img width="904" alt="Screenshot 2022-07-15 at 16 38 05" src="https://user-images.githubusercontent.com/56876663/179246954-f99cbe8e-4d17-4a6b-97d4-d00db65f1ba6.png">

