### PR TITLE
Add Leasehold and Right to Buy to production environment

### DIFF
--- a/auth-groups.json
+++ b/auth-groups.json
@@ -17,6 +17,7 @@
     "Electoral Services": "elections-team",
     "Repairs Contact Centre": "repairs-contact-centre-team",
     "Housing Register": "Housing Register",
-    "Admission and Pupil Benefits": "education-evidence-production"
+    "Admission and Pupil Benefits": "education-evidence-production",
+    "Leasehold and Right to Buy": "Leasehold and Right to Buy"
   }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/DOC-746

## Describe this PR

### *What is the problem we're trying to solve*

Paul Canning has asked for the Leasehold and Right to Buy team to be added to the production (live) environment.

### *What changes have we introduced*

In auth-groups.json, I have added the Google Group 'Leasehold and Right to Buy' to production.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Tell Paul that he should have access to prod now.