### PR TITLE
Update .env.sample with latest envars for Docker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,16 +2,23 @@ APP_URL=http://localdev.hackney.gov.uk:3000
 HACKNEY_COOKIE_NAME=hackneyToken
 NODE_ENV=development
 APP_ENV=development
-EVIDENCE_API_BASE_URL=http://localhost:5000/
+
+EVIDENCE_API_BASE_URL=http://localhost:3001/
+DOCUMENTS_API_BASE_URL=http://localhost:3003/
+#DOCUMENTS_API_BASE_URL=http://localhost:5000/
+# ^this is for cypress and mock server
+
 EVIDENCE_API_TOKEN_DOCUMENT_TYPES_GET=evidence_api_token_document_types_get
 EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_GET=evidence_api_token_evidence_requests_get
 EVIDENCE_API_TOKEN_EVIDENCE_REQUESTS_POST=evidence_api_token_evidence_requests_post
 EVIDENCE_API_TOKEN_DOCUMENT_SUBMISSIONS_PATCH=evidence_api_token_document_submissions_patch
 EVIDENCE_API_TOKEN_DOCUMENT_SUBMISSIONS_GET=evidence_api_token_evidence_requests_get
 EVIDENCE_API_TOKEN_RESIDENTS_GET=evidence_api_token_residents_get
-DOCUMENTS_API_BASE_URL=http://localhost:5000/
+
 DOCUMENTS_API_GET_DOCUMENTS_TOKEN=token
 DOCUMENTS_API_GET_CLAIMS_TOKEN=token
+DOCUMENTS_API_POST_CLAIMS_TOKEN=token
+
 FEEDBACK_FORM_RESIDENT_URL=https://docs.google.com/forms
 FEEDBACK_FORM_STAFF_URL=https://docs.google.com/forms
 SKIP_VERIFY_TOKEN=true

--- a/.env.sample
+++ b/.env.sample
@@ -3,9 +3,12 @@ HACKNEY_COOKIE_NAME=hackneyToken
 NODE_ENV=development
 APP_ENV=development
 
-EVIDENCE_API_BASE_URL=http://localhost:3001/
-DOCUMENTS_API_BASE_URL=http://localhost:3003/
-#DOCUMENTS_API_BASE_URL=http://localhost:5000/
+#EVIDENCE_API_BASE_URL=http://localhost:3001/
+#DOCUMENTS_API_BASE_URL=http://localhost:3003/
+# ^this is for local development
+
+EVIDENCE_API_BASE_URL=http://localhost:5000/
+DOCUMENTS_API_BASE_URL=http://localhost:5000/
 # ^this is for cypress and mock server
 
 EVIDENCE_API_TOKEN_DOCUMENT_TYPES_GET=evidence_api_token_document_types_get


### PR DESCRIPTION
This PR updates the frontend's .env.sample environment variables with the latest API urls, after their Docker files have been reconfigured. More info about that feature can be found here: https://hackney.atlassian.net/browse/DOC-876

Developers will need to make sure that their .env file is up-to-date with these envars in order to do local development with the API containers.

NOTE: I've found that the .env.sample are coupled to Cypress in some way in order to run the tests locally and in the pipeline -- it's not clear how for now, but I've updated the .env.sample to include both set ups. We can have a look into this further when we make a container for the frontend.