### PR TITLE
fix bespoke note formatting in confirm request dialog box

### DIFF
--- a/cypress/integration/create-evidence-request.spec.ts
+++ b/cypress/integration/create-evidence-request.spec.ts
@@ -32,7 +32,7 @@ describe('Create evidence requests', () => {
     cy.get('label').contains('Send request by SMS').click();
 
     cy.get('button').contains('Continue').click();
-    cy.get('label').contains('Proof of ID').click();
+    cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();
     cy.get('button').contains('Continue').click();
 
     cy.get('[data-testid="textarea"]').type(
@@ -64,7 +64,7 @@ describe('Create evidence requests', () => {
       cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
 
       cy.get('button').contains('Continue').click();
-      cy.get('label').contains('Proof of ID').click();
+      cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();
       cy.get('button').contains('Continue').click();
 
       cy.get('button').should('be.disabled');
@@ -77,7 +77,7 @@ describe('Create evidence requests', () => {
       cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
 
       cy.get('button').contains('Continue').click();
-      cy.get('label').contains('Proof of ID').click();
+      cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();
       cy.get('button').contains('Continue').click();
 
       cy.get('button').contains('Skip and Continue').click();
@@ -99,7 +99,7 @@ describe('Create evidence requests', () => {
       cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
 
       cy.get('button').contains('Continue').click();
-      cy.get('label').contains('Proof of ID').click();
+      cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();
       cy.get('button').contains('Continue').click();
 
       cy.get('[data-testid="textarea"]').type('      ');

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -11,7 +11,7 @@ const Field = (props: Props): JSX.Element => (
       disabled={props.disabled}
       className="govuk-checkboxes__input"
     />
-    <label htmlFor={props.id} className="govuk-label govuk-checkboxes__label">
+    <label htmlFor={props.id} className="govuk-label govuk-checkboxes__label" data-testid={props.id}>
       {props.label}
     </label>
   </div>

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -11,7 +11,11 @@ const Field = (props: Props): JSX.Element => (
       disabled={props.disabled}
       className="govuk-checkboxes__input"
     />
-    <label htmlFor={props.id} className="govuk-label govuk-checkboxes__label" data-testid={props.id}>
+    <label
+      htmlFor={props.id}
+      className="govuk-label govuk-checkboxes__label"
+      data-testid={props.id}
+    >
       {props.label}
     </label>
   </div>

--- a/src/components/ConfirmRequestDialog.tsx
+++ b/src/components/ConfirmRequestDialog.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useState } from 'react';
 import Dialog from './Dialog';
-import styles from '../styles/Dialog.module.scss';
+import dialogStyles from '../styles/Dialog.module.scss';
+import insetTextStyles from '../styles/InsetText.module.scss';
 import { EvidenceRequestForm } from 'src/gateways/internal-api';
 import { DocumentType } from 'src/domain/document-type';
 import { useFormikContext } from 'formik';
@@ -64,16 +65,17 @@ const ConfirmRequestDialog: FunctionComponent<Props> = ({
       </ul>
 
       {sanitiseNoteToResident(values.noteToResident) && (
-        <div className="govuk-inset-text lbh-inset-text">
+        <div
+          className={`govuk-inset-text lbh-inset-text
+           ${insetTextStyles.insetText}`}
+        >
           <SVGNoteToResident />
           <strong>Bespoke note to resident</strong>
-          <p className="govuk-!-margin-top-2" style={{ fontStyle: 'italic' }}>
-            {sanitiseNoteToResident(values.noteToResident)}
-          </p>
+          <p>{sanitiseNoteToResident(values.noteToResident)}</p>
         </div>
       )}
 
-      <div className={styles.actions}>
+      <div className={dialogStyles.actions}>
         <button
           className="govuk-button lbh-button"
           disabled={loading}
@@ -91,7 +93,7 @@ const ConfirmRequestDialog: FunctionComponent<Props> = ({
         <button
           onClick={onDismiss}
           type="button"
-          className={`${styles.cancelButton} lbh-body lbh-link`}
+          className={`${dialogStyles.cancelButton} lbh-body lbh-link`}
         >
           No, cancel
         </button>

--- a/src/components/NewRequestFormStep3.tsx
+++ b/src/components/NewRequestFormStep3.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as Yup from 'yup';
 import { TextAreaWithCharacterCount } from './TextAreaWithCharacterCount';
 
-const maxCharacterLength = 400;
+const maxCharacterLength = 5000;
 
 export const schemaNewRequestFormStep3 = Yup.object().shape({
   noteToResident: Yup.string().max(maxCharacterLength),

--- a/src/styles/InsetText.module.scss
+++ b/src/styles/InsetText.module.scss
@@ -1,0 +1,5 @@
+.insetText p {
+  margin-bottom: 0;
+  font-style: italic;
+  white-space: pre-line;
+}


### PR DESCRIPTION
## Link to JIRA ticket

[DOC-1011](https://hackney.atlassian.net/browse/DOC-1011)

## Describe this PR

### *What is the problem we're trying to solve*

Consistent formatting of bespoke notes across all pages.
The officer should be able to see line breaks in a bespoke note when confirming a request.


### *What changes have we introduced*

Add a separate style for inset text and apply the style to the bespoke note

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [] Checked all code for possible refactoring
- [] Code pipeline builds correctly

### *Follow up actions after merging PR*

Demo the changes to Tyrone.  Look into testing for styles/formatting
