### PR TITLE
Add error when no delivery method is selected

### DIFF
--- a/cypress/integration/create-evidence-request.spec.ts
+++ b/cypress/integration/create-evidence-request.spec.ts
@@ -56,12 +56,23 @@ describe('Create evidence requests', () => {
     cy.get('body').contains('Thanks!');
   });
 
+  it('shows an error when no delivery method was selected', () => {
+    cy.visit(`http://localhost:3000/teams/2/dashboard/requests/new/1`);
+
+    cy.get('label').contains('Name').next('input').type('Frodo Baggins');
+    cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
+
+    cy.get('button').contains('Continue').click();
+    cy.get('span').contains('Please provide at least one delivery method');
+  });
+
   describe('When a user has not entered in text for note to resident', () => {
     it('they cannot click continue', () => {
       cy.visit(`http://localhost:3000/teams/2/dashboard/requests/new/1`);
 
       cy.get('label').contains('Name').next('input').type('Frodo Baggins');
       cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
+      cy.get('[data-testid="emailCheckbox"]').click();
 
       cy.get('button').contains('Continue').click();
       cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();
@@ -75,6 +86,7 @@ describe('Create evidence requests', () => {
 
       cy.get('label').contains('Name').next('input').type('Frodo Baggins');
       cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
+      cy.get('[data-testid="emailCheckbox"]').click();
 
       cy.get('button').contains('Continue').click();
       cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();
@@ -97,6 +109,7 @@ describe('Create evidence requests', () => {
 
       cy.get('label').contains('Name').next('input').type('Frodo Baggins');
       cy.get('label').contains('Email').next('input').type('frodo@bagend.com');
+      cy.get('[data-testid="emailCheckbox"]').click();
 
       cy.get('button').contains('Continue').click();
       cy.get('[data-testid="proof-of-id"]').contains('Proof of ID').click();

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -18,6 +18,11 @@ const Field = (props: Props): JSX.Element => (
     >
       {props.label}
     </label>
+    {props.error && (
+      <span className="govuk-error-message lbh-error-message">
+        <span className="govuk-visually-hidden">Error:</span> {props.error}
+      </span>
+    )}
   </div>
 );
 
@@ -27,6 +32,7 @@ export interface Props {
   id: string;
   value?: string;
   disabled?: boolean;
+  error?: string | string[] | null;
 }
 
 export default Field;

--- a/src/components/NewRequestFormStep1.tsx
+++ b/src/components/NewRequestFormStep1.tsx
@@ -9,30 +9,44 @@ import * as Yup from 'yup';
 
 const emailOrPhoneNumberMessage =
   'Please provide either an email or a phone number';
+const atLeastOneDeliveryMethodMessage =
+  'Please provide at least one delivery method';
 
-export const schemaNewRequestFormStep1 = Yup.object().shape({
-  resident: Yup.object().shape(
-    {
-      name: Yup.string().required("Please enter the resident's name"),
-      email: Yup.string().when(['phoneNumber'], {
-        is: (phoneNumber) => !phoneNumber,
-        then: Yup.string()
-          .required(emailOrPhoneNumberMessage)
-          .email('Please provide a valid email address'),
-      }),
-      phoneNumber: Yup.string().when(['email'], {
-        is: (email) => !email,
-        then: Yup.string()
-          .required(emailOrPhoneNumberMessage)
-          .matches(/^\+?[\d]{6,14}$/, 'Please provide a valid phone number'),
-      }),
-    },
-    [['email', 'phoneNumber']]
-  ),
-  team: Yup.string(),
-  reason: Yup.string(),
-  deliveryMethods: Yup.array(),
-});
+export const schemaNewRequestFormStep1 = Yup.object().shape(
+  {
+    resident: Yup.object().shape(
+      {
+        name: Yup.string().required("Please enter the resident's name"),
+        email: Yup.string().when(['phoneNumber'], {
+          is: (phoneNumber) => !phoneNumber,
+          then: Yup.string()
+            .required(emailOrPhoneNumberMessage)
+            .email('Please provide a valid email address'),
+        }),
+        phoneNumber: Yup.string().when(['email'], {
+          is: (email) => !email,
+          then: Yup.string()
+            .required(emailOrPhoneNumberMessage)
+            .matches(/^\+?[\d]{6,14}$/, 'Please provide a valid phone number'),
+        }),
+      },
+      [['email', 'phoneNumber']]
+    ),
+    team: Yup.string(),
+    reason: Yup.string(),
+    emailCheckbox: Yup.array().when(['phoneNumberCheckbox'], {
+      is: (phoneNumberCheckbox) =>
+        phoneNumberCheckbox && !phoneNumberCheckbox[0],
+      then: Yup.array().min(1, atLeastOneDeliveryMethodMessage),
+    }),
+    phoneNumberCheckbox: Yup.array().when(['emailCheckbox'], {
+      is: (emailCheckbox) => emailCheckbox && !emailCheckbox[0],
+      then: Yup.array().min(1, atLeastOneDeliveryMethodMessage),
+    }),
+    deliveryMethods: Yup.array(),
+  },
+  [['emailCheckbox', 'phoneNumberCheckbox']]
+);
 
 const NewRequestFormStep1 = ({ team }: Props): JSX.Element => {
   const { errors, values, touched } = useFormikContext<EvidenceRequestForm>();
@@ -75,6 +89,11 @@ const NewRequestFormStep1 = ({ team }: Props): JSX.Element => {
             id="emailCheckbox"
             value={values.resident?.email}
             disabled={values.resident?.email ? false : true}
+            error={
+              touched.emailCheckbox && values.resident.email
+                ? errors.emailCheckbox
+                : null
+            }
           />
           <Checkbox
             label="Send request by SMS"
@@ -82,6 +101,11 @@ const NewRequestFormStep1 = ({ team }: Props): JSX.Element => {
             id="phoneNumberCheckbox"
             value={values.resident?.phoneNumber}
             disabled={values.resident?.phoneNumber ? false : true}
+            error={
+              touched.phoneNumberCheckbox && values.resident?.phoneNumber
+                ? errors.phoneNumberCheckbox
+                : null
+            }
           />
         </div>
       </div>


### PR DESCRIPTION
Link to Jira card: 
https://hackney.atlassian.net/browse/DOC-739

Fixed a bug where the user was able to progress to the next step of the create evidence request form when no delivery method was selected. Now the page shows an error when trying to continue with no delivery method selected.

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/54269120/184833863-625202a5-f5df-4bcc-a4e8-d67a48d51adf.png">
