### PR TITLE
Fix error for non-existent date when accepting a document

### DIFF
--- a/src/components/AcceptDialog.test.tsx
+++ b/src/components/AcceptDialog.test.tsx
@@ -54,6 +54,95 @@ describe('AcceptDialog', () => {
     });
   });
 
+  it('throws error when impossible date is entered', async () => {
+    render(
+      <AcceptDialog
+        open={true}
+        onDismiss={mockHandler}
+        staffSelectedDocumentTypes={staffSelectedDocumentTypes}
+        email="email@email"
+        documentSubmissionId="123"
+        redirect="foo"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Proof of ID'));
+
+    fireEvent.change(screen.getByTestId('input-day'), {
+      target: { value: '31' },
+    });
+    fireEvent.change(screen.getByTestId('input-month'), {
+      target: { value: '2' },
+    });
+    fireEvent.change(screen.getByTestId('input-year'), {
+      target: { value: '2022' },
+    });
+
+    fireEvent.click(screen.getByText(yesAcceptButtonText));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a valid date'));
+    });
+  });
+
+  it('throws error when incomplete date is entered', async () => {
+    render(
+      <AcceptDialog
+        open={true}
+        onDismiss={mockHandler}
+        staffSelectedDocumentTypes={staffSelectedDocumentTypes}
+        email="email@email"
+        documentSubmissionId="123"
+        redirect="foo"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Proof of ID'));
+
+    fireEvent.change(screen.getByTestId('input-day'), {
+      target: { value: '1' },
+    });
+    fireEvent.change(screen.getByTestId('input-year'), {
+      target: { value: '2023' },
+    });
+
+    fireEvent.click(screen.getByText(yesAcceptButtonText));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please enter a valid date'));
+    });
+  });
+
+  it('validates that a possible date is entered', async () => {
+    render(
+      <AcceptDialog
+        open={true}
+        onDismiss={mockHandler}
+        staffSelectedDocumentTypes={staffSelectedDocumentTypes}
+        email="email@email"
+        documentSubmissionId="123"
+        redirect="foo"
+      />
+    );
+
+    fireEvent.click(screen.getByText('Proof of ID'));
+
+    fireEvent.change(screen.getByTestId('input-day'), {
+      target: { value: '12' },
+    });
+    fireEvent.change(screen.getByTestId('input-month'), {
+      target: { value: '12' },
+    });
+    fireEvent.change(screen.getByTestId('input-year'), {
+      target: { value: '2022' },
+    });
+
+    fireEvent.click(screen.getByText(yesAcceptButtonText));
+
+    const errorMessage = screen.queryByText('Please enter a valid date');
+    expect(errorMessage).not.toBeInTheDocument();
+  });
+
   it('checks submit button is disabled', async () => {
     render(
       <AcceptDialog

--- a/src/components/AcceptDialog.tsx
+++ b/src/components/AcceptDialog.tsx
@@ -173,7 +173,10 @@ const AcceptDialog: FunctionComponent<Props> = (props) => {
                   </span>
                 )}
                 {touched.validUntilDates && (
-                  <span className="govuk-error-message lbh-error-message">
+                  <span
+                    data-testid="error-invalid-date"
+                    className="govuk-error-message lbh-error-message"
+                  >
                     {errors.validUntilDates}
                   </span>
                 )}

--- a/src/components/AcceptDialog.tsx
+++ b/src/components/AcceptDialog.tsx
@@ -12,12 +12,37 @@ import {
 import { DocumentState } from '../domain/document-submission';
 import DateFields from './DateFields';
 import router from 'next/router';
+import { DateTime } from 'luxon';
 
 const schema = Yup.object().shape({
   staffSelectedDocumentTypeId: Yup.string().required(
     'Please choose a document type'
   ),
+  validUntilDates: Yup.array().test(
+    'is-date',
+    'Please enter a valid date',
+    (values) => isDate(values)
+  ),
 });
+
+const isDate = (
+  validUntilDates: string[] | null | undefined | unknown[]
+): boolean => {
+  if (
+    validUntilDates?.every(
+      (x: string | null | undefined | unknown) => x == undefined
+    )
+  )
+    return true;
+
+  const concatDates = validUntilDates?.join('-');
+  if (concatDates) {
+    const parseDate = DateTime.fromFormat(concatDates, 'd-L-yyyy');
+    return !parseDate?.invalidReason;
+  } else {
+    return true;
+  }
+};
 
 const initialValues = {
   state: DocumentState.APPROVED,
@@ -60,7 +85,10 @@ const AcceptDialog: FunctionComponent<Props> = (props) => {
     values: DocumentSubmissionUpdateForm,
     userUpdatedBy: string
   ) => {
-    if (values.validUntilDates && values.validUntilDates.length > 0) {
+    if (
+      values.validUntilDates &&
+      !values.validUntilDates.every((x: string) => x == '' || undefined)
+    ) {
       return {
         state: values.state,
         userUpdatedBy: userUpdatedBy,
@@ -142,6 +170,11 @@ const AcceptDialog: FunctionComponent<Props> = (props) => {
                 {submitError && (
                   <span className="govuk-error-message lbh-error-message">
                     {errorMessage}
+                  </span>
+                )}
+                {touched.validUntilDates && (
+                  <span className="govuk-error-message lbh-error-message">
+                    {errors.validUntilDates}
                   </span>
                 )}
                 <DateFields name="validUntilDates" />

--- a/src/components/DateFields.tsx
+++ b/src/components/DateFields.tsx
@@ -17,6 +17,7 @@ const DateFields = (props: Props): JSX.Element => (
         </label>
         <FormikField
           name={`${props.name}.[0]`}
+          data-testid="input-day"
           id="day"
           className="govuk-input govuk-date-input__input govuk-input--width-2"
           type="text"
@@ -30,6 +31,7 @@ const DateFields = (props: Props): JSX.Element => (
         </label>
         <FormikField
           name={`${props.name}.[1]`}
+          data-testid="input-month"
           id="month"
           className="govuk-input govuk-date-input__input govuk-input--width-2"
           type="text"
@@ -43,6 +45,7 @@ const DateFields = (props: Props): JSX.Element => (
         </label>
         <FormikField
           name={`${props.name}.[2]`}
+          data-testid="input-year"
           id="year"
           className="govuk-input govuk-date-input__input govuk-input--width-2"
           type="text"


### PR DESCRIPTION
In this PR, I've added in some validation to the Yup schema to check if the date that a user has inputted is valid.

So now, there are a few scenarios that are now covered:

1. A user does not input a date. The validation lets this happen and the following request is sent to the API
<img width="500" alt="Screenshot 2022-08-17 at 13 46 42" src="https://user-images.githubusercontent.com/56876663/185162027-d99a3645-e3f0-4e09-8c23-0453d3891d4a.png">
2. A user inputs a possible 
<img width="511" alt="Screenshot 2022-08-17 at 13 46 13" src="https://user-images.githubusercontent.com/56876663/185164557-5db20c62-d8b3-467d-be42-ea9ad2894a16.png">
date. The validation lets this happen and the following request is sent to the API
3. A user inputs a fake date (e.g. 32nd of Dec). The form throws an error.
<img width="551" alt="Screenshot 2022-08-17 at 14 04 11" src="https://user-images.githubusercontent.com/56876663/185174654-134cea0b-3b94-4c84-8131-15fc188d3492.png">
4. If a user enters a date, then removes it, the form will reset the validation and the following request will be sent to the API
<img width="500" alt="Screenshot 2022-08-17 at 13 46 42" src="https://user-images.githubusercontent.com/56876663/185174793-678d44d0-a65e-4895-abb9-8edba2b7f1b5.png">

Any dates that are entered in the past is handled by the API (business logic, rather than view logic, would sit in there). 

In the case of services integrated with our API, we parse the date in `UpdateDocumentSubmissionStateseCase.cs` and it is safely captured by a `BadRequestException`, so we don't need to do any validation at that level either.
```
private async Task<Claim> UpdateClaim(DocumentSubmission documentSubmission, DocumentSubmissionUpdateRequest request)
        {
            try
            {
                var claimId = Guid.Parse(documentSubmission.ClaimId);
                var claimUpdateRequest = new ClaimUpdateRequest { ValidUntil = DateTime.Parse(request.ValidUntil, new CultureInfo("en-GB")) };
                var claim = await _documentsApiGateway.UpdateClaim(claimId, claimUpdateRequest).ConfigureAwait(true);
                return claim;
            }
            catch (DocumentsApiException ex)
            {
                throw new BadRequestException(ex.Message);
            }
        }
```