### PR TITLE
Move state change to catch block to prevent button re-enabling

### DIFF
--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -40,7 +40,6 @@ const UploaderForm: FunctionComponent<Props> = ({
       } catch (err) {
         console.log(err);
         setSubmitError(true);
-      } finally {
         setSubmission(false);
       }
     },


### PR DESCRIPTION
This is to prevent the submit button being re-enabled before the router pushes the user to the next page onSuccess.