### PR TITLE
'Add .heif to accepted mime types'

### DIFF
--- a/src/components/UploaderPanel.tsx
+++ b/src/components/UploaderPanel.tsx
@@ -20,6 +20,7 @@ const acceptedMimeTypes = (): string => {
     'image/bmp', //.bmp
     'image/gif', //.gif
     'image/heic', //.heic
+    'image/heif', //.heif
     'image/jpeg', //.jpeg or .jpg
     'image/png', //.png
     'text/plain', //.txt


### PR DESCRIPTION
Allow MIME-type image/heif files to be accepted so the officer can view documents submitted with that type.
See the ticket for more details
[https://hackney.atlassian.net/browse/DOC-1101](url)

