### PR TITLE
DOC-1162: Amended ResidentPageTable to handle a null email or phoneNumber

### DIFF
--- a/src/components/ConfirmRequestDialog.test.tsx
+++ b/src/components/ConfirmRequestDialog.test.tsx
@@ -9,7 +9,6 @@ import {
 import ConfirmRequestDialog from './ConfirmRequestDialog';
 import DocumentTypesFixture from '../../cypress/fixtures/document_types/index.json';
 import { ResponseMapper } from '../boundary/response-mapper';
-import { EvidenceRequestRequest } from '../gateways/internal-api';
 import { Form, Formik } from 'formik';
 
 const onAccept = jest.fn();
@@ -18,7 +17,7 @@ const documentTypes = DocumentTypesFixture.map(ResponseMapper.mapDocumentType);
 
 describe('Confirm Request Dialog', () => {
   describe('when there is a request', () => {
-    const request: EvidenceRequestRequest = {
+    const request = {
       documentTypes: ['passport'],
       deliveryMethods: ['EMAIL', 'SMS'],
       resident: {
@@ -56,9 +55,9 @@ describe('Confirm Request Dialog', () => {
       ).toBeVisible();
       expect(screen.getByText('For the following evidences:')).toBeVisible();
       expect(screen.getByText('Confirm')).toBeVisible();
-      Object.values(request.resident).forEach((text) =>
-        expect(screen.getByText(text)).toBeVisible()
-      );
+      expect(screen.getByText(request.resident.name)).toBeVisible();
+      expect(screen.getByText(request.resident.email)).toBeVisible();
+      expect(screen.getByText(request.resident.phoneNumber)).toBeVisible();
       expect(screen.getByText('you shall not pass!')).toBeVisible();
       expect.assertions(7);
     });

--- a/src/components/ResidentPageTable.test.tsx
+++ b/src/components/ResidentPageTable.test.tsx
@@ -1,25 +1,17 @@
 import React from 'react';
 import { cleanup, render } from '@testing-library/react';
-import { Resident } from '../domain/resident';
 import ResidentPageTable from './ResidentPageTable';
 
 describe('ResidentPageTable', () => {
   afterEach(cleanup);
-  const resident: Resident = {
-    id: '123',
-    name: 'Frodo',
-    email: 'frodo@bagend.com',
-    phoneNumber: '0123',
-  };
-
-  const residentTwo: Resident = {
-    id: '124',
-    name: 'Fred',
-    email: '',
-    phoneNumber: '',
-  };
 
   test('it renders correctly', async () => {
+    const resident = {
+      id: '123',
+      name: 'Frodo',
+      email: 'frodo@bagend.com',
+      phoneNumber: '0123',
+    };
     const componentTestOne = render(<ResidentPageTable resident={resident} />);
     expect(componentTestOne.getByTestId('name-cell')).toHaveTextContent(
       'Frodo'
@@ -32,20 +24,43 @@ describe('ResidentPageTable', () => {
     );
   });
 
-  test("displays '-' as value if either email or mobile is missing", () => {
-    const componentTestTwo = render(
-      <ResidentPageTable resident={residentTwo} />
-    );
-    expect(componentTestTwo.getByTestId('name-cell')).toHaveTextContent('Fred');
-    expect(
-      componentTestTwo.getByTestId('blankNumber-cell')
-    ).toBeInTheDocument();
-    expect(componentTestTwo.getByTestId('blankNumber-cell')).toHaveTextContent(
-      '-'
-    );
-    expect(componentTestTwo.getByTestId('blankEmail-cell')).toBeInTheDocument();
-    expect(componentTestTwo.getByTestId('blankEmail-cell')).toHaveTextContent(
-      '-'
-    );
-  });
+  for (const { testName, email, phoneNumber } of [
+    {
+      testName: 'displays placeholder when email or phoneNumber are empty',
+      email: '',
+      phoneNumber: '',
+    },
+    {
+      testName: 'displays placeholder when email or phoneNumber are null',
+      email: null,
+      phoneNumber: null,
+    },
+  ]) {
+    test(testName, () => {
+      const resident = {
+        id: '123',
+        name: 'Frodo',
+        email,
+        phoneNumber,
+      };
+      const componentTestTwo = render(
+        <ResidentPageTable resident={resident} />
+      );
+      expect(componentTestTwo.getByTestId('name-cell')).toHaveTextContent(
+        resident.name
+      );
+      expect(
+        componentTestTwo.getByTestId('blankNumber-cell')
+      ).toBeInTheDocument();
+      expect(
+        componentTestTwo.getByTestId('blankNumber-cell')
+      ).toHaveTextContent('-');
+      expect(
+        componentTestTwo.getByTestId('blankEmail-cell')
+      ).toBeInTheDocument();
+      expect(componentTestTwo.getByTestId('blankEmail-cell')).toHaveTextContent(
+        '-'
+      );
+    });
+  }
 });

--- a/src/components/ResidentPageTable.tsx
+++ b/src/components/ResidentPageTable.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react';
 
 const ResidentPageTable: FunctionComponent<Props> = (props) => {
   const { resident } = props;
+
   return (
     <table className="govuk-table lbh-table">
       <tbody className="govuk-table__body">
@@ -18,7 +19,7 @@ const ResidentPageTable: FunctionComponent<Props> = (props) => {
           <th scope="row" className="govuk-table__header">
             Mobile number
           </th>
-          {resident.phoneNumber.length ? (
+          {resident.phoneNumber?.length ? (
             <td className="govuk-table__cell" data-testid="number-cell">
               {resident.phoneNumber}
             </td>
@@ -32,7 +33,7 @@ const ResidentPageTable: FunctionComponent<Props> = (props) => {
           <th scope="row" className="govuk-table__header">
             Email address
           </th>
-          {resident.email.length ? (
+          {resident.email?.length ? (
             <td className="govuk-table__cell" data-testid="email-cell">
               {resident.email}
             </td>

--- a/src/domain/resident.ts
+++ b/src/domain/resident.ts
@@ -1,15 +1,15 @@
 export interface IResident {
   name: string;
-  email: string;
-  phoneNumber: string;
+  email: string | null;
+  phoneNumber: string | null;
   id: string;
   referenceId?: string;
 }
 
 export class Resident implements IResident {
   name: string;
-  email: string;
-  phoneNumber: string;
+  email: string | null;
+  phoneNumber: string | null;
   id: string;
   referenceId?: string;
 


### PR DESCRIPTION
Link to Jira card:
https://hackney.atlassian.net/browse/DOC-1162

Fixed a bug where the user was unable to access the resident's page for users who's email or phoneNumber was `null`. The frontend code was unable to handle the case where the Evidence API returned a value of `null` for either of these fields. This PR adds the code to handle that scenario and will substitute the `null` value with a placeholder on the page.