### PR TITLE
DOC-1202: Displaying warning while documents are uploading

### DIFF
--- a/src/components/PageWarning.tsx
+++ b/src/components/PageWarning.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 
 const PageWarning: FunctionComponent<Props> = (props) => {
   return (

--- a/src/components/UploaderForm.test.tsx
+++ b/src/components/UploaderForm.test.tsx
@@ -63,6 +63,15 @@ describe('UploaderForm', () => {
     });
   });
 
+  it('displays a message to discourage closing the window when submitting', async () => {
+    attachFile('Proof of ID');
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText('Your documents are being uploaded.'));
+    });
+  });
+
   // See DOC-964 for more details about this commented section.
   // it('validates at least one file is attached to each UploaderPanel', async () => {
   //   submitForm();

--- a/src/components/UploaderForm.test.tsx
+++ b/src/components/UploaderForm.test.tsx
@@ -68,7 +68,7 @@ describe('UploaderForm', () => {
     submitForm();
 
     await waitFor(() => {
-      expect(screen.getByText('Your documents are being uploaded.'));
+      expect(screen.getByText('Your documents are being uploaded'));
     });
   });
 

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -77,6 +77,7 @@ const UploaderForm: FunctionComponent<Props> = ({
               className="govuk-button lbh-button"
               type="submit"
               disabled={!dirty || submission}
+              title="Your documents are being uploaded. Please do not close or refresh this page."
             >
               Continue
             </button>

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -59,7 +59,16 @@ const UploaderForm: FunctionComponent<Props> = ({
               There was an error. Please try again later
             </span>
           )}
-
+          {submission && (
+            <section className="lbh-page-announcement lbh-page-announcement--warning">
+              <h3 className="lbh-page-announcement__title">
+                Your documents are being uploaded.{' '}
+              </h3>
+              <div className="lbh-page-announcement__content">
+                Please do not close or refresh this page.
+              </div>
+            </section>
+          )}
           {documentTypes.map((documentType) => (
             <UploaderPanel
               setFieldValue={setFieldValue}
@@ -77,7 +86,6 @@ const UploaderForm: FunctionComponent<Props> = ({
               className="govuk-button lbh-button"
               type="submit"
               disabled={!dirty || submission}
-              title="Your documents are being uploaded. Please do not close or refresh this page."
             >
               Continue
             </button>

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -62,8 +62,8 @@ const UploaderForm: FunctionComponent<Props> = ({
           )}
           {submission && (
             <PageWarning
-              title="Your documents are being uploaded."
-              content="Please do not close or refresh this page."
+              title="Your documents are being uploaded"
+              content="Please do not close or refresh this page"
             />
           )}
           {documentTypes.map((documentType) => (

--- a/src/components/UploaderForm.tsx
+++ b/src/components/UploaderForm.tsx
@@ -9,6 +9,7 @@ import UploaderPanel from './UploaderPanel';
 import { UploadFormModel } from '../services/upload-form-model';
 import { DocumentType } from '../domain/document-type';
 import { LoadingBox } from 'govuk-react';
+import PageWarning from 'src/components/PageWarning';
 
 const getError = (
   id: string,
@@ -60,14 +61,10 @@ const UploaderForm: FunctionComponent<Props> = ({
             </span>
           )}
           {submission && (
-            <section className="lbh-page-announcement lbh-page-announcement--warning">
-              <h3 className="lbh-page-announcement__title">
-                Your documents are being uploaded.{' '}
-              </h3>
-              <div className="lbh-page-announcement__content">
-                Please do not close or refresh this page.
-              </div>
-            </section>
+            <PageWarning
+              title="Your documents are being uploaded."
+              content="Please do not close or refresh this page."
+            />
           )}
           {documentTypes.map((documentType) => (
             <UploaderPanel


### PR DESCRIPTION
We will displaying a warning to discourage residents closing or reloading the browser window while their documents are uploading.

![Screenshot 2022-09-22 114650](https://user-images.githubusercontent.com/86296201/191740612-f70de737-87da-4fd3-9997-ecbd6291aeb3.jpg)

This is to minimise those instances where records are created but documents never reach S3.