### PR TITLE
DOC 1214 - Reword confirmation messages to residents following upload

### DIFF
--- a/cypress/integration/upload-a-document.spec.ts
+++ b/cypress/integration/upload-a-document.spec.ts
@@ -77,7 +77,7 @@ describe('Can upload a document', () => {
       cy.get('button').contains('Continue').should('have.attr', 'disabled');
 
       // View confirmation
-      cy.get('h1').should('contain', "We've received your documents");
+      cy.get('h1').should('contain', 'We’re checking your documents');
       cy.get('p').should(
         'contain',
         `Your reference number: ${residentReferenceId}`
@@ -128,7 +128,7 @@ describe('Can upload a document', () => {
       cy.get('button').contains('Continue').should('have.attr', 'disabled');
 
       // View confirmation
-      cy.get('h1').should('contain', "We've received your documents");
+      cy.get('h1').should('contain', 'We’re checking your documents');
       cy.get('p').should(
         'contain',
         `Your reference number: ${residentReferenceId}`

--- a/src/components/EvidenceAwaitingSubmissionTile.test.tsx
+++ b/src/components/EvidenceAwaitingSubmissionTile.test.tsx
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 
 describe('EvidenceAwaitingSubmissionTile', () => {
   it('renders the expected data', () => {
+    Date.now = jest.fn(() => new Date(Date.UTC(2022, 8, 1)).valueOf()); //added this as the descriptive part after the date meant the test kept failing as more than a month had passed
     const date = DateTime.local(2022, 8, 25, 11, 28).setLocale('en-gb');
     render(
       <EvidenceAwaitingSubmissionTile

--- a/src/components/EvidenceAwaitingSubmissionTile.test.tsx
+++ b/src/components/EvidenceAwaitingSubmissionTile.test.tsx
@@ -5,7 +5,6 @@ import { DateTime } from 'luxon';
 
 describe('EvidenceAwaitingSubmissionTile', () => {
   it('renders the expected data', () => {
-    Date.now = jest.fn(() => new Date(Date.UTC(2022, 8, 1)).valueOf()); //added this as the descriptive part after the date meant the test kept failing as more than a month had passed
     const date = DateTime.local(2022, 8, 25, 11, 28).setLocale('en-gb');
     render(
       <EvidenceAwaitingSubmissionTile
@@ -17,7 +16,11 @@ describe('EvidenceAwaitingSubmissionTile', () => {
     );
     expect(screen.getByText('Proof of ID'));
     expect(
-      screen.getByText('Date requested: 11:28 am 25 August 2022 (last month)')
+      screen.getByText(
+        'Date requested: 11:28 am 25 August 2022 (' +
+          date.toRelativeCalendar() +
+          ')'
+      )
     );
     expect(screen.getByText('Requested by example@example.com'));
     expect(screen.getByText('this is a reason'));

--- a/src/pages/resident/[requestId]/confirmation.tsx
+++ b/src/pages/resident/[requestId]/confirmation.tsx
@@ -29,7 +29,7 @@ const Confirmation: NextPage<ConfirmationProps> = ({
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <Panel>
-            <h1 className="lbh-heading-h1">We've received your documents</h1>
+            <h1 className="lbh-heading-h1">We’re checking your documents</h1>
             <p className="lbh-body">
               Your reference number: {residentReferenceId}
             </p>
@@ -40,8 +40,8 @@ const Confirmation: NextPage<ConfirmationProps> = ({
           <h2 className="lbh-heading-h2">What happens next</h2>
           <p className="lbh-body">{team.slaMessage}</p>
           <p className="lbh-body">
-            We’ve sent your evidence to the service that requested it. They will
-            be in touch about the next steps.
+            We’re checking your evidence. It’ll be sent to the service that
+            requested it if it meets our requirements.
           </p>
           <p className="lbh-body">
             <a href={`${feedbackUrl}`} className="govuk-link lbh-link">


### PR DESCRIPTION
This PR aims to change the wording in the confirmation page so the residents are aware that there are still checks to be carried out on uploaded documents.

"We've received your documents" becomes "We’re checking your documents"

"We’ve sent your evidence to the service that requested it. They will be in touch about the next steps." becomes "We’re checking your evidence. It’ll be sent to the service that requested it if it meets our requirements."

There is also a small change to a preexisting test that kept failing (using the toRelativeCalendar function to compare date to return a consistent result, in order for it to be compared to the test)