### PR TITLE
Add aspect ratio and remove imageWidth calculation

### DIFF
--- a/src/components/ImagePreview.tsx
+++ b/src/components/ImagePreview.tsx
@@ -11,7 +11,6 @@ const ImagePreview = (props: Props): JSX.Element | null => {
   const [loading, setLoading] = useState(true);
   const [rotation, setRotation] = useState('');
   const [currentRotation, setCurrentRotation] = useState(0);
-  const [imageWidth, setImageWidth] = useState(0);
 
   const { documentSubmission, downloadUrl } = props;
   const { document } = documentSubmission;
@@ -65,28 +64,12 @@ const ImagePreview = (props: Props): JSX.Element | null => {
       }
     }, []);
   }
-
-  const getImageWidth = () => {
-    const img = new Image();
-    img.src = downloadUrl;
-    return (img.onload = function () {
-      const width = img.naturalWidth;
-      setImageWidth(width);
-      return width;
-    });
-  };
-
-  useEffect(() => {
-    getImageWidth();
-  }, [downloadUrl]);
-
   return (
     <div>
       <figure className={styles.preview}>
         {documentExtensions.includes(documentExtension as string) ? (
           <RotateDocument
             currentRotation={currentRotation}
-            imageWidth={imageWidth}
             documentSource={downloadUrl}
             rotate={() => rotate(currentRotation)}
             rotation={rotation}
@@ -102,7 +85,6 @@ const ImagePreview = (props: Props): JSX.Element | null => {
           >
             <RotateDocument
               currentRotation={currentRotation}
-              imageWidth={imageWidth}
               documentSource={conversionImage}
               rotate={() => rotate(currentRotation)}
               rotation={rotation}

--- a/src/components/RotateDocument.tsx
+++ b/src/components/RotateDocument.tsx
@@ -3,7 +3,6 @@ import rotated from '../styles/RotateImage.module.scss';
 
 const RotateDocument: FunctionComponent<Props> = ({
   currentRotation,
-  imageWidth,
   documentSource,
   rotate,
   rotation,
@@ -18,7 +17,9 @@ const RotateDocument: FunctionComponent<Props> = ({
           ? {
               display: 'inline-block',
               position: 'relative',
-              height: `${imageWidth}px`,
+              aspectRatio: '1 / 1',
+              height: '100%',
+              width: '100%',
             }
           : { display: 'inline-block', position: 'relative' }
       }
@@ -50,7 +51,6 @@ const RotateDocument: FunctionComponent<Props> = ({
 
 type Props = {
   currentRotation: number;
-  imageWidth: number;
   documentSource: string;
   rotate: (currentRotation: number) => void;
   rotation: string;


### PR DESCRIPTION
Link to Jira card:
https://hackney.atlassian.net/browse/DOC-1013

- Added aspect ratio to display the image correctly when turned at 90 degree and 270 degrees.
- Removed the calculation of image width as we don't need the initial width, but the one after the image is resized.