### PR TITLE
Add DocumentSubmissionResponseObject to match the response from evidence-api

### DIFF
--- a/cypress/fixtures/document_submissions/get-many-response-object.json
+++ b/cypress/fixtures/document_submissions/get-many-response-object.json
@@ -1,0 +1,153 @@
+{
+  "documentSubmissions": [
+    {
+      "documentType": {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity",
+        "enabled": true
+      },
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "createdAt": "2021-01-14T10:23:42.958Z",
+      "evidenceRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "claimId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "claimValidUntil": "2121-01-29T16:28:11.326Z",
+      "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
+      "rejectionReason": "string",
+      "state": "UPLOADED",
+      "document": {
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "createdAt": "2021-01-29T16:28:11.326Z",
+        "fileSize": 25300,
+        "fileType": "image/png"
+      }
+    },
+    {
+      "documentType": {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity",
+        "enabled": true
+      },
+      "id": "2a220753-9a7c-428d-98cd-73999d733bfb",
+      "createdAt": "2021-01-14T10:23:42.958Z",
+      "evidenceRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+      "claimId": "2a220753-9a7c-428d-98cd-73999d733bfb",
+      "claimValidUntil": "2121-01-29T16:28:11.326Z",
+      "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
+      "rejectionReason": "string",
+      "state": "UPLOADED",
+      "document": {
+        "id": "2a220753-9a7c-428d-98cd-73999d733bfb",
+        "createdAt": "2021-01-29T16:28:11.326Z",
+        "fileSize": 55300,
+        "fileType": "application/pdf"
+      }
+    },
+    {
+      "documentType": {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity",
+        "enabled": true
+      },
+      "id": "f4ced259-53b3-446a-b4c2-98cb160b1722",
+      "createdAt": "2022-01-14T10:23:42.958Z",
+      "evidenceRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
+      "claimId": "g4ced259-53b3-446a-b4c2-98cb160b1722",
+      "claimValidUntil": "2121-01-29T16:28:11.326Z",
+      "retentionExpiresAt": "2022-04-14T10:23:42.958Z",
+      "rejectionReason": "string",
+      "state": "UPLOADED",
+      "document": {
+        "id": "f4ced259-53b3-446a-b4c2-98cb160b1722",
+        "createdAt": "2022-01-29T16:28:11.326Z",
+        "fileSize": 10000,
+        "fileType": "image/heic"
+      }
+    },
+    {
+      "documentType": {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity",
+        "enabled": true
+      },
+      "staffSelectedDocumentType": {
+        "id": "passport-scan",
+        "title": "Passport",
+        "description": "A valid passport open at the photo page",
+        "enabled": true
+      },
+      "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+      "createdAt": "2020-12-25T10:23:42.958Z",
+      "evidenceRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+      "claimValidUntil": "2121-01-29T16:28:11.326Z",
+      "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
+      "rejectionReason": "string",
+      "state": "APPROVED",
+      "userUpdatedBy": "approver1@email.com",
+      "document": {
+        "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+        "createdAt": "2021-01-29T16:28:11.326Z",
+        "fileSize": 25300,
+        "fileType": "image/png"
+      }
+    },
+    {
+      "documentType": {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity",
+        "enabled": true
+      },
+      "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
+      "createdAt": "2020-12-30T10:23:42.958Z",
+      "evidenceRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+      "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
+      "claimValidUntil": "2121-01-29T16:28:11.326Z",
+      "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
+      "rejectionReason": "some rejection reason",
+      "rejectedAt": "2021-01-14T10:23:42.958Z",
+      "state": "REJECTED",
+      "userUpdatedBy": "rejecter@email.com",
+      "document": {
+        "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773447",
+        "createdAt": "2021-01-29T16:28:11.326Z",
+        "fileSize": 25300,
+        "fileType": "image/png"
+      }
+    },
+    {
+      "documentType": {
+        "id": "proof-of-id",
+        "title": "Proof of ID",
+        "description": "A valid document that can be used to prove identity",
+        "enabled": true
+      },
+      "staffSelectedDocumentType": {
+        "id": "passport-scan",
+        "title": "Passport",
+        "description": "A valid passport open at the photo page",
+        "enabled": true
+      },
+      "id": "c82120d2-0a5c-4f40-bdcd-5a18d877344v",
+      "createdAt": "2020-12-25T10:23:42.958Z",
+      "evidenceRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa8",
+      "claimId": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+      "claimValidUntil": "2000-01-29T16:28:11.326Z",
+      "retentionExpiresAt": "2021-04-14T10:23:42.958Z",
+      "rejectionReason": "string",
+      "state": "APPROVED",
+      "userUpdatedBy": "approver2@email.com",
+      "document": {
+        "id": "c82120d2-0a5c-4f40-bdcd-5a18d8773446",
+        "createdAt": "2021-01-29T16:28:11.326Z",
+        "fileSize": 25300,
+        "fileType": "image/png"
+      }
+    }
+  ],
+  "total": 10
+}

--- a/src/gateways/evidence-api.test.ts
+++ b/src/gateways/evidence-api.test.ts
@@ -2,7 +2,7 @@ import { AxiosInstance, AxiosResponse } from 'axios';
 import { ResponseMapper } from 'src/boundary/response-mapper';
 import { EvidenceRequestState } from 'src/domain/enums/EvidenceRequestState';
 import DocumentSubmissionFixture from '../../cypress/fixtures/document_submissions/get-png.json';
-import DocumentSubmissionsFixture from '../../cypress/fixtures/document_submissions/get-many.json';
+import DocumentSubmissionsResponseObjectFixture from '../../cypress/fixtures/document_submissions/get-many-response-object.json';
 import EvidenceRequestFixture from '../../cypress/fixtures/evidence_requests/index.json';
 import { EvidenceApiGateway } from './evidence-api';
 import { InternalServerError } from './internal-api';
@@ -615,8 +615,8 @@ describe('Evidence api gateway', () => {
     const residentId = 'id';
     const team = 'service';
     describe('returns the correct response', () => {
-      const expectedData = DocumentSubmissionsFixture;
-      const mappedData = expectedData.map((ds) =>
+      const expectedData = DocumentSubmissionsResponseObjectFixture;
+      const mappedData = expectedData.documentSubmissions.map((ds) =>
         ResponseMapper.mapDocumentSubmission(ds)
       );
 
@@ -659,7 +659,7 @@ describe('Evidence api gateway', () => {
           residentId
         );
 
-        expectedData.map((ds) =>
+        expectedData.documentSubmissions.map((ds) =>
           expect(
             mockedResponseMapper.mapDocumentSubmission
           ).toHaveBeenCalledWith(ds)

--- a/src/gateways/evidence-api.ts
+++ b/src/gateways/evidence-api.ts
@@ -1,6 +1,7 @@
 import Axios, { AxiosInstance, Method } from 'axios';
 import {
   DocumentSubmissionResponse,
+  DocumentSubmissionResponseObject,
   EvidenceRequestResponse,
   ResidentResponse,
   TokenDictionary,
@@ -165,7 +166,7 @@ export class EvidenceApiGateway {
     residentId: string
   ): Promise<DocumentSubmission[]> {
     try {
-      const { data } = await this.client.get<DocumentSubmissionResponse[]>(
+      const { data } = await this.client.get<DocumentSubmissionResponseObject>(
         '/api/v1/document_submissions',
         {
           headers: {
@@ -178,7 +179,9 @@ export class EvidenceApiGateway {
           },
         }
       );
-      return data.map((ds) => ResponseMapper.mapDocumentSubmission(ds));
+      return data.documentSubmissions.map((ds) =>
+        ResponseMapper.mapDocumentSubmission(ds)
+      );
     } catch (err) {
       console.error(err);
       throw new InternalServerError('Internal server error');

--- a/test/mocks/fixtures/document-submissions.js
+++ b/test/mocks/fixtures/document-submissions.js
@@ -3,7 +3,7 @@ const documentSubmissionPdf = require('../../../cypress/fixtures/document_submis
 const documentSubmissionHeic = require('../../../cypress/fixtures/document_submissions/get-heic.json');
 const approvedDocumentSubmission = require('../../../cypress/fixtures/document_submissions/get-approved.json');
 const rejectedDocumentSubmission = require('../../../cypress/fixtures/document_submissions/get-rejected.json');
-const documentSubmissionsWithResident = require('../../../cypress/fixtures/document_submissions/get-many.json');
+const documentSubmissionsWithResident = require('../../../cypress/fixtures/document_submissions/get-many-response-object.json');
 const documentSubmissionExpiredClaim = require('../../../cypress/fixtures/document_submissions/get-expired.json');
 
 // There may be a neater way of doing this with MocksServer variants but I couldn't get it to work.

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -48,6 +48,11 @@ export interface DocumentSubmissionResponse
   document?: DocumentResponse;
 }
 
+export interface DocumentSubmissionResponseObject {
+  documentSubmissions: DocumentSubmissionResponse[];
+  total: number;
+}
+
 export interface DocumentResponse {
   id: string;
   fileSize: number;


### PR DESCRIPTION
Added `DocumentSubmissionResponseObject` to match the response received from evidence-api when getting document submissions for a resident.