### PR TITLE
Add document description to the EvidenceTile

### DIFF
--- a/cypress/integration/view-and-manage-evidence.spec.ts
+++ b/cypress/integration/view-and-manage-evidence.spec.ts
@@ -552,7 +552,6 @@ describe('Can view and manage evidence', () => {
       cy.get('h1').should('contain', 'Upload documents');
       cy.get('button').contains('Submit').click();
       cy.get('span').contains('Please select a document type');
-      cy.get('span').contains('Please enter a description');
       cy.get('span').contains('Please select a file');
     });
 

--- a/src/boundary/response-mapper.ts
+++ b/src/boundary/response-mapper.ts
@@ -91,6 +91,10 @@ export class ResponseMapper {
   }
 
   private static mapDocument(attrs: DocumentResponse): Document {
-    return new Document({ ...attrs, fileSizeInBytes: attrs.fileSize });
+    return new Document({
+      ...attrs,
+      fileSizeInBytes: attrs.fileSize,
+      description: attrs.description,
+    });
   }
 }

--- a/src/components/EvidenceTile.test.tsx
+++ b/src/components/EvidenceTile.test.tsx
@@ -16,6 +16,7 @@ describe('EvidenceTile', () => {
         reason={'housing reason'}
         requestedBy={'ash@dummy.com'}
         userUpdatedBy={'approver1@email.com'}
+        documentDescription={'This is the description'}
       />
     );
     expect(screen.getByText('Foo'));
@@ -24,6 +25,7 @@ describe('EvidenceTile', () => {
     expect(screen.getByText('APPROVED'));
     expect(screen.getByText('Approved by approver1@email.com'));
     expect(screen.getByText('housing reason'));
+    expect(screen.getByText('Description: This is the description'));
   });
 
   it('renders without actions if document has already been reviewed', async () => {
@@ -56,6 +58,7 @@ describe('EvidenceTile', () => {
         reason={undefined}
         requestedBy={undefined}
         userUpdatedBy={null}
+        documentDescription={undefined}
       />
     );
 

--- a/src/components/EvidenceTile.tsx
+++ b/src/components/EvidenceTile.tsx
@@ -15,6 +15,7 @@ export const EvidenceTile: FunctionComponent<Props> = ({
   reason,
   requestedBy,
   userUpdatedBy,
+  documentDescription,
 }) => {
   enum tagColour {
     UPLOADED = 'lbh-tag lbh-tag--blue',
@@ -50,6 +51,11 @@ export const EvidenceTile: FunctionComponent<Props> = ({
                 <p className={`lbh-body-s ${styles.meta}`}>
                   Date uploaded: {createdAt}
                 </p>
+                {documentDescription && (
+                  <p className={`lbh-body-s ${styles.meta}`}>
+                    Description: {documentDescription}
+                  </p>
+                )}
                 {reason && (
                   <p className={`lbh-body-s ${styles.meta}`}>{reason}</p>
                 )}
@@ -99,4 +105,5 @@ interface Props {
   reason: string | undefined;
   requestedBy: string | undefined;
   userUpdatedBy: string | null;
+  documentDescription?: string | undefined;
 }

--- a/src/components/ResidentDocumentsTable.tsx
+++ b/src/components/ResidentDocumentsTable.tsx
@@ -272,6 +272,9 @@ export const ResidentDocumentsTable: FunctionComponent<Props> = ({
                                     userUpdatedBy={
                                       documentTabItem.userUpdatedBy
                                     }
+                                    documentDescription={
+                                      documentTabItem.document?.description
+                                    }
                                   />
                                 </li>
                               </>

--- a/src/components/StaffUploaderForm.tsx
+++ b/src/components/StaffUploaderForm.tsx
@@ -32,7 +32,7 @@ export const validationSchema = Yup.object().shape({
         }
       ),
       description: Yup.string().max(
-        5,
+        255,
         'Description must be between 0 and 255 characters'
       ),
       files: Yup.mixed().test(

--- a/src/components/StaffUploaderForm.tsx
+++ b/src/components/StaffUploaderForm.tsx
@@ -31,7 +31,10 @@ export const validationSchema = Yup.object().shape({
           return value !== 'Please select';
         }
       ),
-      description: Yup.string().required('Please enter a description'),
+      description: Yup.string().max(
+        5,
+        'Description must be between 0 and 255 characters'
+      ),
       files: Yup.mixed().test(
         'at-least-one-file',
         'Please select a file',

--- a/src/domain/document.ts
+++ b/src/domain/document.ts
@@ -4,17 +4,20 @@ export interface IDocument {
   id: string;
   fileSizeInBytes: number;
   fileType: string;
+  description?: string;
 }
 
 export class Document implements IDocument {
   id: string;
   fileSizeInBytes: number;
   fileType: string;
+  description?: string;
 
   constructor(params: IDocument) {
     this.id = params.id;
     this.fileSizeInBytes = params.fileSizeInBytes;
     this.fileType = params.fileType;
+    this.description = params.description;
   }
 
   get extension(): string | undefined {

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -57,6 +57,7 @@ export interface DocumentResponse {
   id: string;
   fileSize: number;
   fileType: string;
+  description?: string;
 }
 
 export interface ResidentResponse {


### PR DESCRIPTION
Added document description to the EvidenceTile so it's easier for our users to identify what that document is before clicking on it from the resident's page.