### PR TITLE
DOC-1359: Proper visualisation when there's no awaiting submission ERs

### DIFF
--- a/src/components/ResidentDocumentsTable.tsx
+++ b/src/components/ResidentDocumentsTable.tsx
@@ -158,7 +158,9 @@ export const ResidentDocumentsTable: FunctionComponent<Props> = ({
                 style={{ borderLeftColor: documentTab.style }}
               >
                 <EvidenceList>
-                  {documentTab.id === 'awaiting-submission' ? (
+                  {documentTab.id === 'awaiting-submission' &&
+                  awaitingSubmissions &&
+                  awaitingSubmissions.length > 0 ? (
                     awaitingSubmissions.map((x, i) => (
                       <li
                         className={styles.item}
@@ -173,7 +175,9 @@ export const ResidentDocumentsTable: FunctionComponent<Props> = ({
                         />
                       </li>
                     ))
-                  ) : documentSubmissions && documentSubmissions.length > 0 ? (
+                  ) : documentTab.id != 'awaiting-submission' &&
+                    documentSubmissions &&
+                    documentSubmissions.length > 0 ? (
                     documentSubmissions.map((documentSubmission, index) => (
                       <>
                         <li


### PR DESCRIPTION
In the [previous iteration ](https://github.com/LBHackney-IT/document-evidence-store-frontend/pull/283), when there were no evidence requests in the Awaiting Submission tab, the "There are no documents to review" label was not displayed correctly. 
This PR remediates that.