### PR TITLE
TS-1966: Make the pipeline persist only needed folders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - .build
-            #- node_modules
+            - ./build
+            - ./node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ commands:
         type: string
         default: staging
     steps:
-      - *attach_workspace
       - checkout
       - run:
           name: Install serverless CLI
@@ -63,7 +62,6 @@ jobs:
   build:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
       - node/install-packages
       - run:
@@ -78,7 +76,6 @@ jobs:
   lint-and-test:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
       - run:
           name: Run linter
@@ -100,7 +97,6 @@ jobs:
   run-cypress-e2e:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
       - run:
           name: Copy envs
@@ -117,7 +113,6 @@ jobs:
   sonar-scan:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
       - sonarcloud/scan
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - aws
+            - ./aws
 
   deploy-lambda:
     description: 'Deploys application'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,16 +31,12 @@ commands:
 
     steps:
       - checkout
-      - attach_workspace:
-          at: *workspace_root
       - aws_assume_role/assume_role:
           account: <<parameters.aws-account>>
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
       - persist_to_workspace:
           root: *workspace_root
-          paths:
-            - ./aws
 
   deploy-lambda:
     description: 'Deploys application'
@@ -51,7 +47,7 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -68,7 +64,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - node/install-packages
       - run:
           name: Build Next application
@@ -84,7 +80,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - run:
           name: Run linter
           command: npm run lint:ci
@@ -107,7 +103,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - run:
           name: Copy envs
           command: cp .env.sample .env
@@ -125,7 +121,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - sonarcloud/scan
 
   assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,12 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: '~'
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
       - run:
           name: Deploy application
-          root: '~'
           command: |
             npm prune --omit=dev                      
             sls deploy -s <<parameters.stage>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ workflows:
             branches:
               only:
                 - main
-                - TS-1966                
+                - TS-1966
 
       - deploy-staging:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,9 @@ commands:
           name: Stalking
           command: find ~
       - persist_to_workspace:
-          root: *workspace_root
+          root: ~
           paths:
-            - ~/.aws
+            - .aws
 
   deploy-lambda:
     description: 'Deploys application'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ commands:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - .aws
+            - build
+            - node_modules
 
   deploy-lambda:
     description: 'Deploys application'
@@ -175,6 +176,7 @@ workflows:
             branches:
               only:
                 - main
+                - TS-1966                
 
       - deploy-staging:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - ~/.aws
+            - ./.aws
 
   deploy-lambda:
     description: 'Deploys application'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ commands:
           role: 'LBH_Circle_CI_Deployment_Role'
       - persist_to_workspace:
           root: *workspace_root
+          paths:
+            - ~/.aws
 
   deploy-lambda:
     description: 'Deploys application'
@@ -47,7 +49,7 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -64,7 +66,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - node/install-packages
       - run:
           name: Build Next application
@@ -80,7 +82,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - run:
           name: Run linter
           command: npm run lint:ci
@@ -103,7 +105,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - run:
           name: Copy envs
           command: cp .env.sample .env
@@ -121,7 +123,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root
+          at: *workspace_root      
       - sonarcloud/scan
 
   assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - build
-            - node_modules
+            - .build
+            #- node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ commands:
           paths:
             - .aws
 
-
   deploy-lambda:
     description: 'Deploys application'
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ commands:
         default: staging
     steps:
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ commands:
           account: <<parameters.aws-account>>
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
+      - run:
+          name: Stalking
+          command: find .     
       - persist_to_workspace:
           root: *workspace_root
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -64,7 +64,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - node/install-packages
       - run:
           name: Build Next application
@@ -80,7 +80,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - run:
           name: Run linter
           command: npm run lint:ci
@@ -103,7 +103,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - run:
           name: Copy envs
           command: cp .env.sample .env
@@ -121,7 +121,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - sonarcloud/scan
 
   assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - build
-            - node_modules
+            - ./build
+            - ./node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ commands:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - .aws
+            - aws
 
   deploy-lambda:
     description: 'Deploys application'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - .build
-            - .node_modules
+            - build
+            - node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
           name: Stalking
           command: find ~
       - persist_to_workspace:
-          root: ~
+          root: '~'
           paths:
             - .aws
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
       - image: cimg/python:3.7
 
 references:
-  workspace_root: &workspace_root '~'
+  workspace_root: &workspace_root '.'
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ commands:
           command: sudo npm i -g serverless
       - run:
           name: Deploy application
+          root: '~'
           command: |
             npm prune --omit=dev                      
             sls deploy -s <<parameters.stage>>
@@ -130,7 +131,6 @@ jobs:
     executor: python
     steps:
       - assume-role-and-persist-workspace:
-          root: '~'
           aws-account: $AWS_ACCOUNT_STAGING
 
   assume-role-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - build
-            - node_modules
+            - .build
+            - .node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - node/install-packages
       - run:
           name: Build Next application
-          command: npm run build --omit=dev
+          command: npm run build 
       - persist_to_workspace:
           root: *workspace_root
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,8 @@ commands:
         type: string
         default: staging
     steps:
+      - *attach_workspace
       - checkout
-      - attach_workspace:
-          at: *workspace_root      
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -64,6 +63,7 @@ jobs:
   build:
     executor: node
     steps:
+      - *attach_workspace
       - checkout
       - node/install-packages
       - run:
@@ -78,6 +78,7 @@ jobs:
   lint-and-test:
     executor: node
     steps:
+      - *attach_workspace
       - checkout
       - run:
           name: Run linter
@@ -99,6 +100,7 @@ jobs:
   run-cypress-e2e:
     executor: node
     steps:
+      - *attach_workspace
       - checkout
       - run:
           name: Copy envs
@@ -115,6 +117,7 @@ jobs:
   sonar-scan:
     executor: node
     steps:
+      - *attach_workspace
       - checkout
       - sonarcloud/scan
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - aws_assume_role/assume_role:
           account: <<parameters.aws-account>>
           profile_name: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,12 @@ jobs:
   build:
     executor: node
     steps:
-      - checkout
       - *attach_workspace
+      - checkout
       - node/install-packages
       - run:
           name: Build Next application
-          command: npm run build
+          command: npm run build --omit=dev
       - persist_to_workspace:
           root: *workspace_root
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -66,7 +66,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - node/install-packages
       - run:
           name: Build Next application
@@ -82,7 +82,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - run:
           name: Run linter
           command: npm run lint:ci
@@ -105,7 +105,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - run:
           name: Copy envs
           command: cp .env.sample .env
@@ -123,7 +123,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: *workspace_root      
+          at: *workspace_root
       - sonarcloud/scan
 
   assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,6 @@ workflows:
             branches:
               only:
                 - main
-                - TS-1966
 
       - deploy-staging:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ commands:
 
     steps:
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - aws_assume_role/assume_role:
           account: <<parameters.aws-account>>
           profile_name: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
           root: *workspace_root
           paths:
             - build
-            - node_modules
+          #  - node_modules
 
   deploy-lambda:
     description: 'Deploys application'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
           paths:
             - build
             - node_modules
+            - ./.aws
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,9 @@ commands:
         type: string
         default: staging
     steps:
-      - *attach_workspace
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - run:
           name: Install serverless CLI
           command: sudo npm i -g serverless
@@ -63,8 +64,9 @@ jobs:
   build:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - node/install-packages
       - run:
           name: Build Next application
@@ -78,8 +80,9 @@ jobs:
   lint-and-test:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - run:
           name: Run linter
           command: npm run lint:ci
@@ -100,8 +103,9 @@ jobs:
   run-cypress-e2e:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - run:
           name: Copy envs
           command: cp .env.sample .env
@@ -117,8 +121,9 @@ jobs:
   sonar-scan:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
+      - attach_workspace:
+          at: *workspace_root      
       - sonarcloud/scan
 
   assume-role-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - ./build
-            - ./node_modules
+            - build
+            - node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ commands:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - build
-          #  - node_modules
+            - .aws
+
 
   deploy-lambda:
     description: 'Deploys application'
@@ -73,7 +73,8 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - .
+            - build
+            - node_modules
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
           role: 'LBH_Circle_CI_Deployment_Role'
       - run:
           name: Stalking
-          command: find .     
+          command: find .
       - persist_to_workspace:
           root: *workspace_root
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,11 @@ commands:
           role: 'LBH_Circle_CI_Deployment_Role'
       - run:
           name: Stalking
-          command: find .
+          command: find ~
       - persist_to_workspace:
           root: *workspace_root
           paths:
-            - ./.aws
+            - ~/.aws
 
   deploy-lambda:
     description: 'Deploys application'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,6 @@ jobs:
           paths:
             - build
             - node_modules
-            - ./.aws
 
   lint-and-test:
     executor: node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,12 @@ jobs:
   build:
     executor: node
     steps:
-      - *attach_workspace
       - checkout
+      - *attach_workspace
       - node/install-packages
       - run:
           name: Build Next application
-          command: npm run build 
+          command: npm run build
       - persist_to_workspace:
           root: *workspace_root
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ commands:
           account: <<parameters.aws-account>>
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-      - run:
-          name: Stalking
-          command: find ~
       - persist_to_workspace:
           root: '~'
           paths:
@@ -133,6 +130,7 @@ jobs:
     executor: python
     steps:
       - assume-role-and-persist-workspace:
+          root: '~'
           aws-account: $AWS_ACCOUNT_STAGING
 
   assume-role-production:

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lbh-frontend": "^3.5.3",
         "luxon": "^1.25.0",
         "mime-types": "^2.1.28",
-        "next": "^12.3.4",
+        "next": "^12.3.5",
         "react": "^17.0.2",
         "react-dom": "17.0.2",
         "restana": "^4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lbh-frontend": "^3.5.3",
         "luxon": "^1.25.0",
         "mime-types": "^2.1.28",
-        "next": "^12.3.5",
+        "next": "^12.3.4",
         "react": "^17.0.2",
         "react-dom": "17.0.2",
         "restana": "^4.8.0",


### PR DESCRIPTION
Currently, the pipeline is persisting the entire workspace where this should be just node_modules and build files.
This PR introduces such changes.
Apologies for the 40+ commits, yaml is not my mother tongue.